### PR TITLE
Fix CORE index self-link

### DIFF
--- a/AI/CORE/CORE.md
+++ b/AI/CORE/CORE.md
@@ -1,6 +1,3 @@
 # CORE
 
 Core, non-negotiable rules that apply to all projects.
-
-## Files
-- [CORE.md](CORE.md)


### PR DESCRIPTION
## Summary
- remove the self-referential link in CORE index

## Testing
- not run (docs-only change)

Closes #7