### PR TITLE
Describe AI index links

### DIFF
--- a/AI/AI-RULES/STRUCTURE.md
+++ b/AI/AI-RULES/STRUCTURE.md
@@ -12,6 +12,7 @@ Rules for organizing the ai-rules repository itself (not downstream projects).
 - Category index files should only link one level down.
 - In index files, each "## Files" entry should include a short one-line description when helpful.
 - Do not add headings that only link to another file; use the "## Files" list instead.
+- In `AI/AI.md`, add a one-line description for every link to help navigation.
 
 ## AI-RULES Area
 - Meta-guidance lives under `AI/AI-RULES/`.

--- a/AI/AI.md
+++ b/AI/AI.md
@@ -4,43 +4,43 @@ This index is the single entry point for the baseline rules. Each level links
 only one level deeper to keep navigation predictable.
 
 ## CORE
-- [CORE/CORE.md](CORE/CORE.md)
+- [CORE/CORE.md](CORE/CORE.md) - Core, non-negotiable rules.
 
 ## AI-RULES
-- [AI-RULES/AI-RULES.md](AI-RULES/AI-RULES.md)
+- [AI-RULES/AI-RULES.md](AI-RULES/AI-RULES.md) - Meta-guidance for maintaining this repository.
 
 ## REVIEW
-- [REVIEW/REVIEW.md](REVIEW/REVIEW.md)
+- [REVIEW/REVIEW.md](REVIEW/REVIEW.md) - Code review guidance.
 
 ## SECURITY
-- [SECURITY/SECURITY.md](SECURITY/SECURITY.md)
+- [SECURITY/SECURITY.md](SECURITY/SECURITY.md) - Security guidance.
 
 ## TEST
-- [TEST/TEST.md](TEST/TEST.md)
+- [TEST/TEST.md](TEST/TEST.md) - Testing guidance.
 
 ## LANGUAGE
-- [LANGUAGE/LANGUAGE.md](LANGUAGE/LANGUAGE.md)
+- [LANGUAGE/LANGUAGE.md](LANGUAGE/LANGUAGE.md) - Language and coding guidance.
 
 ## DESIGN
-- [DESIGN/DESIGN.md](DESIGN/DESIGN.md)
+- [DESIGN/DESIGN.md](DESIGN/DESIGN.md) - Design and code-quality guidance.
 
 ## ARCHITECTURE
-- [ARCHITECTURE/ARCHITECTURE.md](ARCHITECTURE/ARCHITECTURE.md)
+- [ARCHITECTURE/ARCHITECTURE.md](ARCHITECTURE/ARCHITECTURE.md) - Architecture patterns and guidance.
 
 ## FRAMEWORK
-- [FRAMEWORK/FRAMEWORK.md](FRAMEWORK/FRAMEWORK.md)
+- [FRAMEWORK/FRAMEWORK.md](FRAMEWORK/FRAMEWORK.md) - Framework-specific rules.
 
 ## BUILD_TOOLS
-- [BUILD_TOOLS/BUILD_TOOLS.md](BUILD_TOOLS/BUILD_TOOLS.md)
+- [BUILD_TOOLS/BUILD_TOOLS.md](BUILD_TOOLS/BUILD_TOOLS.md) - Build and dependency tools.
 
 ## LIBRARY
-- [LIBRARY/LIBRARY.md](LIBRARY/LIBRARY.md)
+- [LIBRARY/LIBRARY.md](LIBRARY/LIBRARY.md) - Library-specific guidance.
 
 ## COMPLIANCE
-- [COMPLIANCE/COMPLIANCE.md](COMPLIANCE/COMPLIANCE.md)
+- [COMPLIANCE/COMPLIANCE.md](COMPLIANCE/COMPLIANCE.md) - Compliance and license rules.
 
 ## CI-CD
-- [CI-CD/CI-CD.md](CI-CD/CI-CD.md)
+- [CI-CD/CI-CD.md](CI-CD/CI-CD.md) - CI/CD guidance.
 
 ## INFRASTRUCTURE
-- [INFRASTRUCTURE/INFRASTRUCTURE.md](INFRASTRUCTURE/INFRASTRUCTURE.md)
+- [INFRASTRUCTURE/INFRASTRUCTURE.md](INFRASTRUCTURE/INFRASTRUCTURE.md) - Infrastructure guidance.


### PR DESCRIPTION
## Summary
- add one-line descriptions for links in AI/AI.md
- codify the AI index description rule in AI-RULES structure guidance

## Testing
- not run (docs-only change)