### PR TITLE
Add installation prompts to README

### DIFF
--- a/AGENTS_TEMPLATE.md
+++ b/AGENTS_TEMPLATE.md
@@ -46,13 +46,5 @@ Use the shared AI rules located at:
 > Keeping `.github/copilot-instructions.md` present and pointed at the baseline
 > increases the chance it uses the same rules.
 
-## Updates
-To pull new baseline rules later:
-  git subtree pull --prefix docs/ai https://github.com/fabian-barney/ai-rules.git main --squash
-
-## Conventions
-- Root-level docs use UPPERCASE filenames.
-- Avoid case-only renames on Windows.
-
 ## Access
 This repository is private; ensure your GitHub account has access.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This repository contains shared, versioned AI guidance intended to be vendored
 into other projects (e.g., via git subtree). It is the single source of truth
 for baseline agent rules across repositories.
 
-## Getting started
+## Getting Started
 
 ### Initial setup
 1. Copy `AGENTS_TEMPLATE.md` into your project root as `AGENTS.md`.


### PR DESCRIPTION
﻿## Summary
- add Getting Started section with initial setup and update prompts
- clarify that omitting the version uses the latest tagged release
- remove redundant Setup Template section
- move AI/AI.md entry point into the Structure list
- clarify AI/AI.md as the single entry point for the entire ruleset
- remove redundant Update Prompt subsection
- add descriptions for Contributing and Changelog entries
- remove Updates and Conventions from AGENTS_TEMPLATE

## Testing
- not run (docs-only change)