### PR TITLE
Add Windows CRLF note for subtree setup

### DIFF
--- a/AGENTS_TEMPLATE.md
+++ b/AGENTS_TEMPLATE.md
@@ -16,11 +16,13 @@ still available if the setup is interrupted.
 
      ```
      git config --local core.autocrlf true
-     git ls-files -m
+     git add --renormalize .
+     git status --porcelain
      ```
 
-     If `git ls-files -m` is still non-empty and you have no real local changes,
-     clean the working tree (stash/commit your real work first).
+     If `git status --porcelain` is empty, continue. If not, stash/commit any
+     real work first. If there are no real changes, you may discard them only
+     after explicit confirmation (for example, `git reset --hard`).
 2. Baseline entry point (after subtree add):
    docs/ai/AI/AI.md
 3. Create a local overlay for project-specific rules (recommended):


### PR DESCRIPTION
## Summary
- add Windows CRLF line-ending troubleshooting note for subtree setup failures
- scope core.autocrlf config to the repo (--local) so AI setup avoids changing global Git settings

## Testing
- not run (docs change)

Closes #25