### PR TITLE
Forbid cascading ternary operators in readability rules

### DIFF
--- a/LANGUAGE/READABILITY.md
+++ b/LANGUAGE/READABILITY.md
@@ -20,7 +20,8 @@ Rules to promote readable code and low cognitive complexity.
 - Avoid deeply nested expressions as function arguments; compute intermediate
   values first so the intent is obvious.
 - Name intermediate values to reflect meaning, not mechanics.
-- Cascading ternary operators are strictly forbidden.
+- Cascading ternary operators (nested or chained ternary expressions) are
+  strictly forbidden.
 
 ## Naming and Structure
 - Use clear, descriptive names for variables, methods, and classes.


### PR DESCRIPTION
## Summary
- add an explicit readability rule that cascading ternary operators are strictly forbidden

Closes #39