### PR TITLE
docs: add execution guide links in consuming project doc

### DIFF
--- a/AI-RULES/CONSUMING_PROJECT.md
+++ b/AI-RULES/CONSUMING_PROJECT.md
@@ -8,6 +8,11 @@ project/repository.
 - Keep the ai-rules subtree replaceable by updates.
 - Store project-specific guidance and lessons learned outside the vendor path.
 
+## Execution Guidance
+- For planning, see [PLAN/PLAN.md](../PLAN/PLAN.md).
+- For implementation, see [PROGRAMMING/PROGRAMMING.md](../PROGRAMMING/PROGRAMMING.md).
+- For review, see [REVIEW/REVIEW.md](../REVIEW/REVIEW.md).
+
 ## Recommended Layout
 - Vendor ai-rules under `docs/ai/AI-RULES/`.
 - Baseline entry point: `docs/ai/AI-RULES/AI.md`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Added consuming-project VCS workflow guidance for branch-per-concern,
   pushing working intermediate states, non-working-code exception handling,
   and PR/MR suggestion timing.
+- Added execution guidance links from `AI-RULES/CONSUMING_PROJECT.md` to
+  `PLAN/PLAN.md`, `PROGRAMMING/PROGRAMMING.md`, and `REVIEW/REVIEW.md`.
 
 ## [v3.0.1] - 2026-02-06
 - Clarified update/setup path placeholder handling, including copy-paste-safe


### PR DESCRIPTION
## Summary
- Add an Execution Guidance section to AI-RULES/CONSUMING_PROJECT.md.
- Link directly to:
  - PLAN/PLAN.md
  - PROGRAMMING/PROGRAMMING.md
  - REVIEW/REVIEW.md
- Update CHANGELOG.md (Unreleased) to record the new cross-links.

## Validation
- Docs-only change.
- Verified links point to existing repository paths.

Closes #50
