### PR TITLE
docs: add PR/MR and issue-tracker summary guidance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   and PR/MR suggestion timing.
 - Added execution guidance links from `AI-RULES/CONSUMING_PROJECT.md` to
   `PLAN/PLAN.md`, `PROGRAMMING/PROGRAMMING.md`, and `REVIEW/REVIEW.md`.
+- Added PR/MR and issue-tracker summary rules with template snippets in
+  `CORE/VERSION_CONTROL_SYSTEM.md`, plus a delivery pointer in
+  `PROGRAMMING/PROGRAMMING.md`.
 
 ## [v3.0.1] - 2026-02-06
 - Clarified update/setup path placeholder handling, including copy-paste-safe

--- a/CORE/VERSION_CONTROL_SYSTEM.md
+++ b/CORE/VERSION_CONTROL_SYSTEM.md
@@ -15,6 +15,41 @@ Guidance for version control system usage (Git and others).
 - Do not push knowingly non-working code unless this is explicitly requested.
 - Suggest opening a PR/MR when all acceptance criteria are fulfilled and you
   have access to GitHub, GitLab, or a similar review system.
+- When opening a PR/MR, auto-detect the target branch from consuming-project
+  rules when available; otherwise ask which target branch to use and suggest
+  the most likely one.
+
+## PR/MR and Issue Tracker Summaries
+- When creating a PR/MR, include an implementation summary aimed at code
+  reviewers.
+- If you have access to the review platform, add that summary directly to the
+  PR/MR description or comment thread.
+- Also provide a short bullet-point summary on the linked issue/ticket for
+  Product Owners, Code Reviewers, and Testers/QA.
+- If you have access to the issue tracker, add that summary directly to the
+  linked issue/ticket.
+
+### PR/MR Summary Template (Code Reviewer Audience)
+```md
+## Implementation Summary
+- Scope:
+- Key changes:
+- Non-goals:
+
+## Validation
+- Tests executed:
+- Manual checks:
+- Residual risks:
+```
+
+### Issue Tracker Summary Template (PO/Reviewer/QA Audience)
+```md
+- Delivered:
+- Acceptance criteria status:
+- Validation status:
+- QA notes / test focus:
+- Open risks or follow-ups:
+```
 
 ## Ignore File
 - Maintain a VCS ignore file in the repository root (for Git: `.gitignore`).

--- a/PROGRAMMING/PROGRAMMING.md
+++ b/PROGRAMMING/PROGRAMMING.md
@@ -29,3 +29,5 @@ Guidance for implementing code changes.
 ## Delivery
 - Update documentation or comments when behavior changes.
 - Summarize changes, tests run, and any residual risks.
+- For PR/MR and issue-tracker summary expectations, follow
+  `CORE/VERSION_CONTROL_SYSTEM.md`.


### PR DESCRIPTION
## Implementation Summary
- Add PR/MR and Issue Tracker Summaries guidance to CORE/VERSION_CONTROL_SYSTEM.md.
- Add two template snippets:
  - PR/MR implementation summary template for code reviewers.
  - Issue-tracker bullet summary template for Product Owners, Code Reviewers, and Testers/QA.
- Extend Branch and PR/MR Workflow with target-branch handling:
  - auto-detect from consuming-project rules when available;
  - otherwise ask and suggest the most likely target branch.
- Add a delivery-phase pointer in PROGRAMMING/PROGRAMMING.md to the VCS summary rules.
- Update CHANGELOG.md (Unreleased).

## Validation
- Docs-only change.
- Verified changed markdown formatting and links locally.

Closes #49
