### PR TITLE
docs: define multiline parameter and argument formatting

### DIFF
--- a/LANGUAGE/CONVENTIONS.md
+++ b/LANGUAGE/CONVENTIONS.md
@@ -3,7 +3,7 @@
 ## Formatting
 Formatting rules are ordered by precedence:
 1. Standard, language-specific formatting rules.
-2. The ai-rules conventions in this document regarding formatting.
+2. The ai-rules conventions regarding formatting.
 3. Individual formatting preferences (lowest priority).
 
 ### Rules
@@ -11,15 +11,13 @@ Formatting rules are ordered by precedence:
 - It is not allowed to override standard formatting rules, even by team
   consensus.
 - If not conflicting with standard formatting rules, apply the ai-rules
-  conventions in this document and keep them consistent across the codebase.
+  conventions and keep them consistent across the codebase.
 - For function/method parameter lists and function/method call argument lists
-  with more than 3 items, use multiline formatting in new/changed code when
-  this does not conflict with standard formatting rules.
-- If parameter/argument lists are multiline, place each item on its own line
-  when this does not conflict with standard formatting rules.
+  with more than 3 items, use multiline formatting in new/changed code.
+- If parameter/argument lists are multiline, place each item on its own line.
 - If parameter/argument lists are multiline, require a trailing delimiter (for
   example, a trailing comma in comma-separated lists) on the last item when
-  supported by the language and not disallowed by standard formatting rules.
+  supported by the language.
 
 ## Naming Conventions
 - Use English names by default.


### PR DESCRIPTION
## Implementation Summary
- Add formatting rules in LANGUAGE/CONVENTIONS.md for function/method parameters and call arguments.
- Require multiline formatting when lists have more than 3 items (for new/changed code).
- Require one item per line for multiline lists.
- Require trailing delimiter on the last item when the language supports it.

## Validation
- Docs-only change.

Closes #47
