### PR TITLE
docs: require issue title in commit message guidance

### DIFF
--- a/CORE/VERSION_CONTROL_SYSTEM.md
+++ b/CORE/VERSION_CONTROL_SYSTEM.md
@@ -3,7 +3,9 @@
 Guidance for version control system usage (Git and others).
 
 ## Commit Messages
-- Always reference the ticket or issue identifier in commit messages.
+- Always include the ticket or issue identifier and ticket/issue title (or a
+  concise equivalent summary aligned with that title).
+- Example format: `<ticket-or-issue-id> <ticket-or-issue-title>: <change>`.
 - Add optional context about what changed and why when it improves clarity.
 - Mark breaking changes explicitly.
 


### PR DESCRIPTION
## Implementation Summary
- Update CORE/VERSION_CONTROL_SYSTEM.md commit message guidance to require both issue/ticket identifier and title.
- Add a concise example commit message format that includes both elements.

## Validation
- Docs-only change.

Closes #52
