### PR TITLE
docs: standardize <AI_RULES_PATH> placeholder usage

### DIFF
--- a/AGENTS_TEMPLATE.md
+++ b/AGENTS_TEMPLATE.md
@@ -21,7 +21,7 @@ Define `<AI_RULES_PATH>` as `docs/ai/AI-RULES`.
 
 ### Mode: local (no commits, no push)
 1. Add the ai-rules subtree (creates a local commit):
-   `git subtree add --prefix <AI_RULES_PATH> https://github.com/fabian-barney/ai-rules.git REF --squash`
+   `git subtree add --prefix "<AI_RULES_PATH>" https://github.com/fabian-barney/ai-rules.git REF --squash`
    - Use the requested version tag; otherwise use the latest tagged release.
      If no tags exist, use `main`.
    - If Git requires an author identity, set it locally:
@@ -75,7 +75,7 @@ Local-only update note:
 
 ### Mode: git (tracked in repo)
 1. Add the ai-rules subtree:
-   `git subtree add --prefix <AI_RULES_PATH> https://github.com/fabian-barney/ai-rules.git REF --squash`
+   `git subtree add --prefix "<AI_RULES_PATH>" https://github.com/fabian-barney/ai-rules.git REF --squash`
    - Use the requested version tag; otherwise use the latest tagged release.
      If no tags exist, use `main`.
    - If Git requires an author identity, set it locally:
@@ -115,7 +115,7 @@ Local-only update note:
 8. Commit and push the changes.
 
 Git update note:
-- Use `git subtree pull --prefix <AI_RULES_PATH> https://github.com/fabian-barney/ai-rules.git REF --squash`
+- Use `git subtree pull --prefix "<AI_RULES_PATH>" https://github.com/fabian-barney/ai-rules.git REF --squash`
   and commit the update.
 
 ## Entry Point Templates

--- a/AGENTS_TEMPLATE.md
+++ b/AGENTS_TEMPLATE.md
@@ -17,11 +17,11 @@ To switch modes later, use "mode ai-rules local" or "mode ai-rules git".
 
 ### Vendor path
 ai-rules is vendored under `docs/ai/AI-RULES/`.
-Define `AI_RULES_PATH` as `docs/ai/AI-RULES`.
+Define `<AI_RULES_PATH>` as `docs/ai/AI-RULES`.
 
 ### Mode: local (no commits, no push)
 1. Add the ai-rules subtree (creates a local commit):
-   `git subtree add --prefix AI_RULES_PATH https://github.com/fabian-barney/ai-rules.git REF --squash`
+   `git subtree add --prefix <AI_RULES_PATH> https://github.com/fabian-barney/ai-rules.git REF --squash`
    - Use the requested version tag; otherwise use the latest tagged release.
      If no tags exist, use `main`.
    - If Git requires an author identity, set it locally:
@@ -49,7 +49,7 @@ Define `AI_RULES_PATH` as `docs/ai/AI-RULES`.
    /CLAUDE.md
    /.github/copilot-instructions.md
 4. Baseline entry point (after subtree add):
-   AI_RULES_PATH/AI.md
+   `<AI_RULES_PATH>/AI.md`
 5. Create a local overlay for project-specific rules (recommended):
    AI_PROJECT.md
    Note: keep this outside `docs/ai/` so subtree updates do not overwrite it.
@@ -64,18 +64,18 @@ Define `AI_RULES_PATH` as `docs/ai/AI-RULES`.
    - `CLAUDE.md` (Claude Code)
    - `.github/copilot-instructions.md` (GitHub Copilot)
 9. Replace this template content in `AGENTS.md` with the final references:
-   - Baseline: AI_RULES_PATH/AI.md
+   - Baseline: `<AI_RULES_PATH>/AI.md`
    - Overlay: AI_PROJECT.md
 
 Local-only update note:
 - Follow the local-mode update steps in `AI-RULES/UPDATE.md`.
-  Do not run `git subtree add` on top of an existing `AI_RULES_PATH` directory.
-  If `AI_RULES_PATH` already exists locally, remove it only after confirming
+  Do not run `git subtree add` on top of an existing `<AI_RULES_PATH>` directory.
+  If `<AI_RULES_PATH>` already exists locally, remove it only after confirming
   there is no real work in that directory.
 
 ### Mode: git (tracked in repo)
 1. Add the ai-rules subtree:
-   `git subtree add --prefix AI_RULES_PATH https://github.com/fabian-barney/ai-rules.git REF --squash`
+   `git subtree add --prefix <AI_RULES_PATH> https://github.com/fabian-barney/ai-rules.git REF --squash`
    - Use the requested version tag; otherwise use the latest tagged release.
      If no tags exist, use `main`.
    - If Git requires an author identity, set it locally:
@@ -95,7 +95,7 @@ Local-only update note:
      real work first. If there are no real changes, you may discard them only
      after explicit confirmation (for example, `git reset --hard`).
 2. Baseline entry point (after subtree add):
-   AI_RULES_PATH/AI.md
+   `<AI_RULES_PATH>/AI.md`
 3. Create a local overlay for project-specific rules (recommended):
    AI_PROJECT.md
    Note: keep this outside `docs/ai/` so subtree updates do not overwrite it.
@@ -110,23 +110,23 @@ Local-only update note:
    - `CLAUDE.md` (Claude Code)
    - `.github/copilot-instructions.md` (GitHub Copilot)
 7. Replace this template content in `AGENTS.md` with the final references:
-   - Baseline: AI_RULES_PATH/AI.md
+   - Baseline: `<AI_RULES_PATH>/AI.md`
    - Overlay: AI_PROJECT.md
 8. Commit and push the changes.
 
 Git update note:
-- Use `git subtree pull --prefix AI_RULES_PATH https://github.com/fabian-barney/ai-rules.git REF --squash`
+- Use `git subtree pull --prefix <AI_RULES_PATH> https://github.com/fabian-barney/ai-rules.git REF --squash`
   and commit the update.
 
 ## Entry Point Templates
-Note: Replace `AI_RULES_PATH` with `docs/ai/AI-RULES`.
+Note: Replace `<AI_RULES_PATH>` with `docs/ai/AI-RULES`.
 
 ### CLAUDE.md
 ```
 # CLAUDE
 
 Use the shared AI rules located at:
-- Baseline: AI_RULES_PATH/AI.md
+- Baseline: <AI_RULES_PATH>/AI.md
 - Overlay: AI_PROJECT.md
 ```
 
@@ -135,7 +135,7 @@ Use the shared AI rules located at:
 # Copilot Instructions
 
 Use the shared AI rules located at:
-- Baseline: AI_RULES_PATH/AI.md
+- Baseline: <AI_RULES_PATH>/AI.md
 - Overlay: AI_PROJECT.md
 ```
 

--- a/AGENTS_TEMPLATE.md
+++ b/AGENTS_TEMPLATE.md
@@ -21,7 +21,7 @@ Define `<AI_RULES_PATH>` as `docs/ai/AI-RULES`.
 
 ### Mode: local (no commits, no push)
 1. Add the ai-rules subtree (creates a local commit):
-   `git subtree add --prefix "<AI_RULES_PATH>" https://github.com/fabian-barney/ai-rules.git REF --squash`
+   `git subtree add --prefix <AI_RULES_PATH> https://github.com/fabian-barney/ai-rules.git REF --squash`
    - Use the requested version tag; otherwise use the latest tagged release.
      If no tags exist, use `main`.
    - If Git requires an author identity, set it locally:
@@ -75,7 +75,7 @@ Local-only update note:
 
 ### Mode: git (tracked in repo)
 1. Add the ai-rules subtree:
-   `git subtree add --prefix "<AI_RULES_PATH>" https://github.com/fabian-barney/ai-rules.git REF --squash`
+   `git subtree add --prefix <AI_RULES_PATH> https://github.com/fabian-barney/ai-rules.git REF --squash`
    - Use the requested version tag; otherwise use the latest tagged release.
      If no tags exist, use `main`.
    - If Git requires an author identity, set it locally:
@@ -115,7 +115,7 @@ Local-only update note:
 8. Commit and push the changes.
 
 Git update note:
-- Use `git subtree pull --prefix "<AI_RULES_PATH>" https://github.com/fabian-barney/ai-rules.git REF --squash`
+- Use `git subtree pull --prefix <AI_RULES_PATH> https://github.com/fabian-barney/ai-rules.git REF --squash`
   and commit the update.
 
 ## Entry Point Templates

--- a/AI-RULES/UPDATE.md
+++ b/AI-RULES/UPDATE.md
@@ -8,7 +8,7 @@ Instructions for AI agents to update ai-rules in a consuming project.
 
 ## Update Steps (run when requested)
 1. Locate the vendored ai-rules path and entry point from `AGENTS.md` or README.
-   - Set `AI_RULES_PATH` to the repo-relative path (for example `docs/ai/AI-RULES`).
+   - Set `<AI_RULES_PATH>` to the repo-relative path (for example `docs/ai/AI-RULES`).
    - Every time this guide shows `<AI_RULES_PATH>`, replace it with that real path.
    - For `.git/info/exclude`, the matching directory entry is `/<AI_RULES_PATH>/`
      (for example `/docs/ai/AI-RULES/`).


### PR DESCRIPTION
## Implementation Summary
- Standardize placeholder usage to <AI_RULES_PATH> in setup/update documentation.
- Update AGENTS_TEMPLATE.md placeholder references to match AI-RULES/UPDATE.md style.
- Align the remaining inconsistent placeholder reference in AI-RULES/UPDATE.md.
- Keep concrete literal path examples (e.g., docs/ai/AI-RULES) unchanged.

## Validation
- Docs-only change.
- Audited AI_RULES_PATH references in the repository and aligned placeholder-style entries.

Closes #54
