### PR TITLE
docs: standardize downstream-project terminology

### DIFF
--- a/AGENTS_TEMPLATE.md
+++ b/AGENTS_TEMPLATE.md
@@ -55,11 +55,11 @@ Define `AI_RULES_PATH` as `docs/ai/AI-RULES`.
    Note: keep this outside `docs/ai/` so subtree updates do not overwrite it.
 6. Create a project lessons learned area (recommended):
    docs/ai/LESSONS_LEARNED/LESSONS_LEARNED.md
-   See `AI-RULES/CONSUMING_PROJECT.md` for guidance.
+   See `AI-RULES/DOWNSTREAM-PROJECT.md` for guidance.
 7. Create a project ADR area (recommended):
    docs/ai/DECISIONS/DECISIONS.md
    docs/ai/DECISIONS/ADR-0001-TITLE.md
-   See `AI-RULES/CONSUMING_PROJECT.md` for guidance.
+   See `AI-RULES/DOWNSTREAM-PROJECT.md` for guidance.
 8. Create entry points for other AI tools:
    - `CLAUDE.md` (Claude Code)
    - `.github/copilot-instructions.md` (GitHub Copilot)
@@ -101,11 +101,11 @@ Local-only update note:
    Note: keep this outside `docs/ai/` so subtree updates do not overwrite it.
 4. Create a project lessons learned area (recommended):
    docs/ai/LESSONS_LEARNED/LESSONS_LEARNED.md
-   See `AI-RULES/CONSUMING_PROJECT.md` for guidance.
+   See `AI-RULES/DOWNSTREAM-PROJECT.md` for guidance.
 5. Create a project ADR area (recommended):
    docs/ai/DECISIONS/DECISIONS.md
    docs/ai/DECISIONS/ADR-0001-TITLE.md
-   See `AI-RULES/CONSUMING_PROJECT.md` for guidance.
+   See `AI-RULES/DOWNSTREAM-PROJECT.md` for guidance.
 6. Create entry points for other AI tools:
    - `CLAUDE.md` (Claude Code)
    - `.github/copilot-instructions.md` (GitHub Copilot)

--- a/AI-RULES/AI-RULES.md
+++ b/AI-RULES/AI-RULES.md
@@ -4,16 +4,16 @@ Guidance for maintaining this ai-rules repository.
 
 ## Terminology
 - "ai-rules" refers to this repository's baseline ruleset and its published tags.
-- "downstream project" means a project/repository that vendors and uses
+- "downstream-project" means a project/repository that vendors and uses
   ai-rules.
-- "consuming project" is a legacy synonym for "downstream project".
+- "consuming project" is a legacy synonym for "downstream-project".
 
 ## Files
 - [STRUCTURE.md](STRUCTURE.md) - Structure rules for this repository only.
 - [FORMATTING.md](FORMATTING.md) - Formatting rules for this repository only.
 - [RELEASE.md](RELEASE.md) - Release checklist for this repository.
-- [UPDATE.md](UPDATE.md) - Update workflow and prompt examples for downstream projects.
-- [CONSUMING_PROJECT.md](CONSUMING_PROJECT.md) - Downstream project layout and lessons learned guidance.
+- [UPDATE.md](UPDATE.md) - Update workflow and prompt examples for downstream-projects.
+- [DOWNSTREAM-PROJECT.md](DOWNSTREAM-PROJECT.md) - downstream-project layout and lessons learned guidance.
 - [LESSONS_LEARNED/LESSONS_LEARNED.md](LESSONS_LEARNED/LESSONS_LEARNED.md) - Index of lessons
   to prevent repeat mistakes.
 

--- a/AI-RULES/DOWNSTREAM-PROJECT.md
+++ b/AI-RULES/DOWNSTREAM-PROJECT.md
@@ -1,9 +1,8 @@
-# CONSUMING_PROJECT
+# DOWNSTREAM-PROJECT
 
-Guidance for downstream projects that vendor ai-rules.
-In this documentation, "downstream project" is the primary term.
+Guidance for downstream-projects that vendor ai-rules.
+In this documentation, "downstream-project" is the primary term.
 Legacy wording "consuming project" means the same thing.
-The filename and H1 `CONSUMING_PROJECT` are kept for backward compatibility.
 
 ## Goals
 - Keep the ai-rules subtree replaceable by updates.
@@ -25,7 +24,7 @@ The filename and H1 `CONSUMING_PROJECT` are kept for backward compatibility.
 ## Lessons Learned (project-specific)
 - Create `docs/ai/LESSONS_LEARNED/LESSONS_LEARNED.md` with an index and keep entries as
   `YYYY-MM-DD-short-title.md`.
-- Keep the scope limited to the downstream project and update existing entries
+- Keep the scope limited to the downstream-project and update existing entries
   when the issue repeats.
 
 ## Architecture Decision Records (project-specific)

--- a/AI-RULES/FORMATTING.md
+++ b/AI-RULES/FORMATTING.md
@@ -1,10 +1,10 @@
 # FORMATTING
 
-Formatting rules for the ai-rules repository itself (not downstream projects).
+Formatting rules for the ai-rules repository itself (not downstream-projects).
 
 ## Scope
 - Applies only to this repository.
-- Do not copy these rules into downstream projects.
+- Do not copy these rules into downstream-projects.
 
 ## Markdown
 - Use UTF-8 without BOM.

--- a/AI-RULES/LESSONS_LEARNED/2026-02-01-markdownlint.md
+++ b/AI-RULES/LESSONS_LEARNED/2026-02-01-markdownlint.md
@@ -2,7 +2,7 @@
 
 ## Scope
 - Applies only to this repository.
-- Do not copy these rules into downstream projects.
+- Do not copy these rules into downstream-projects.
 
 ## Issue
 Markdownlint failures after changes (MD013 line length, MD024 duplicate headings,

--- a/AI-RULES/LESSONS_LEARNED/2026-02-01-release-version-examples.md
+++ b/AI-RULES/LESSONS_LEARNED/2026-02-01-release-version-examples.md
@@ -2,7 +2,7 @@
 
 ## Scope
 - Applies only to this repository.
-- Do not copy these rules into downstream projects.
+- Do not copy these rules into downstream-projects.
 
 ## Issue
 During the v2.1.0 and v2.1.1 releases, versioned example prompts in README.md

--- a/AI-RULES/LESSONS_LEARNED/2026-02-03-markdownlint-angle-brackets.md
+++ b/AI-RULES/LESSONS_LEARNED/2026-02-03-markdownlint-angle-brackets.md
@@ -2,7 +2,7 @@
 
 ## Scope
 - Applies only to this repository.
-- Do not copy these rules into downstream projects.
+- Do not copy these rules into downstream-projects.
 
 ## Issue
 Markdownlint failed because placeholder tokens wrapped in angle brackets (for

--- a/AI-RULES/LESSONS_LEARNED/2026-02-04-md012-after-bulk-edits.md
+++ b/AI-RULES/LESSONS_LEARNED/2026-02-04-md012-after-bulk-edits.md
@@ -2,7 +2,7 @@
 
 ## Scope
 - Applies only to this repository.
-- Do not copy these rules into downstream projects.
+- Do not copy these rules into downstream-projects.
 
 ## Issue
 Markdownlint MD012 failures (multiple blank lines) appeared across many files

--- a/AI-RULES/LESSONS_LEARNED/2026-02-04-review-comments-resolution.md
+++ b/AI-RULES/LESSONS_LEARNED/2026-02-04-review-comments-resolution.md
@@ -2,7 +2,7 @@
 
 ## Scope
 - Applies only to this repository.
-- Do not copy these rules into downstream projects.
+- Do not copy these rules into downstream-projects.
 
 ## Issue
 Review comments were deleted instead of resolved, reducing review traceability.

--- a/AI-RULES/LESSONS_LEARNED/LESSONS_LEARNED.md
+++ b/AI-RULES/LESSONS_LEARNED/LESSONS_LEARNED.md
@@ -4,7 +4,7 @@ Compact, actionable notes to prevent repeat mistakes.
 
 ## Scope
 - Applies only to this repository.
-- Do not copy these rules into downstream projects.
+- Do not copy these rules into downstream-projects.
 - Avoid duplicate lessons; update an existing entry if the issue matches.
 - Keep each lesson focused on a single concern. If multiple issues occur, split
   them into separate files.
@@ -16,7 +16,7 @@ Copy and fill in for each lesson learned:
 
 ## Scope
 - Applies only to this repository.
-- Do not copy these rules into downstream projects.
+- Do not copy these rules into downstream-projects.
 
 ## Issue
 What went wrong and why it mattered.

--- a/AI-RULES/RELEASE.md
+++ b/AI-RULES/RELEASE.md
@@ -1,10 +1,10 @@
 # RELEASE
 
-Release process for the ai-rules repository (not downstream projects).
+Release process for the ai-rules repository (not downstream-projects).
 
 ## Scope
 - Applies only to this repository.
-- Do not copy these rules into downstream projects.
+- Do not copy these rules into downstream-projects.
 
 ## AI-Prompted Release
 Example prompts:

--- a/AI-RULES/STRUCTURE.md
+++ b/AI-RULES/STRUCTURE.md
@@ -1,10 +1,10 @@
 # STRUCTURE
 
-Rules for organizing the ai-rules repository itself (not downstream projects).
+Rules for organizing the ai-rules repository itself (not downstream-projects).
 
 ## Scope
 - Applies only to this repository.
-- Do not copy these rules into downstream projects.
+- Do not copy these rules into downstream-projects.
 
 ## Directory Layout
 - Keep top-level categories at the repository root and list them in `AI.md`.
@@ -22,7 +22,7 @@ Rules for organizing the ai-rules repository itself (not downstream projects).
 - Keep repository-standard governance files (for example `CONTRIBUTING.md` and
   `CHANGELOG.md`) scoped to this repository only.
 - `README.md` may include user-facing guidance on how to use ai-rules in
-  downstream projects.
-- Put detailed downstream project operational guidance in
-  `AI-RULES/CONSUMING_PROJECT.md`, `AI-RULES/UPDATE.md`, and
+  downstream-projects.
+- Put detailed downstream-project operational guidance in
+  `AI-RULES/DOWNSTREAM-PROJECT.md`, `AI-RULES/UPDATE.md`, and
   `AGENTS_TEMPLATE.md`.

--- a/AI-RULES/UPDATE.md
+++ b/AI-RULES/UPDATE.md
@@ -1,6 +1,6 @@
 # UPDATE
 
-Instructions for AI agents to update ai-rules in a downstream project.
+Instructions for AI agents to update ai-rules in a downstream-project.
 
 ## Prompt Examples
 - "update ai-rules"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,10 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## Unreleased
-- Added downstream project VCS workflow guidance for branch-per-concern,
+- Added downstream-project VCS workflow guidance for branch-per-concern,
   pushing working intermediate states, non-working-code exception handling,
   and PR/MR suggestion timing.
-- Added execution guidance links from `AI-RULES/CONSUMING_PROJECT.md` to
+- Added execution guidance links from `AI-RULES/DOWNSTREAM-PROJECT.md` to
   `PLAN/PLAN.md`, `PROGRAMMING/PROGRAMMING.md`, and `REVIEW/REVIEW.md`.
 - Added PR/MR and issue-tracker summary rules with template snippets in
   `CORE/VERSION_CONTROL_SYSTEM.md`, plus a delivery pointer in
@@ -18,16 +18,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Clarified update/setup path placeholder handling, including copy-paste-safe
   `.git/info/exclude` examples.
 - Added readability guidance forbidding nested/chained ternary expressions.
-- Added downstream project ADR guidance under `docs/ai/DECISIONS/` and
-  clarified downstream project terminology.
+- Added downstream-project ADR guidance under `docs/ai/DECISIONS/` and
+  clarified downstream-project terminology.
 - Clarified scope boundaries between repository governance files and
-  downstream project operational guidance.
+  downstream-project operational guidance.
 
 ## [v3.0.0] - 2026-02-05
 - Breaking: flattened repo layout with `AI.md` at the repo root and subtree prefix
   guidance updated to `docs/ai/AI-RULES`.
 - Added PROGRAMMING, PLAN, and CODE_REVIEW guidance with stricter review expectations.
-- Added downstream project guidance for lessons learned placement and maintenance rules.
+- Added downstream-project guidance for lessons learned placement and maintenance rules.
 - Added test fixture separation guidance and markdownlint hygiene updates.
 
 ## [v2.2.0] - 2026-02-04

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,7 @@ shared AI guidance, so changes should be deliberate and well-reviewed.
 ## Review Expectations
 - Use PRs for all changes.
 - Verify AI-generated content for correctness and alignment with repo goals.
-- If a change affects downstream project policy, update related AI-RULES docs
+- If a change affects downstream-project policy, update related AI-RULES docs
   and templates in the same PR.
 
 ## Versioning and Releases

--- a/CORE/VERSION_CONTROL_SYSTEM.md
+++ b/CORE/VERSION_CONTROL_SYSTEM.md
@@ -17,7 +17,7 @@ Guidance for version control system usage (Git and others).
 - Do not push knowingly non-working code unless this is explicitly requested.
 - Suggest opening a PR/MR when all acceptance criteria are fulfilled and you
   have access to GitHub, GitLab, or a similar review system.
-- When opening a PR/MR, auto-detect the target branch from downstream project
+- When opening a PR/MR, auto-detect the target branch from downstream-project
   rules when available; otherwise ask which target branch to use and suggest
   the most likely one.
 


### PR DESCRIPTION
## Implementation Summary
- Standardize terminology to **downstream project** as the primary term across affected docs/templates.
- Update AI-RULES/AI-RULES.md terminology section accordingly.
- Add a compatibility note that **consuming project** is a legacy synonym.
- Align related docs that referenced the old term (including structure/formatting/release/update guidance and linked governance text).

## Validation
- Docs-only change.
- Checked for remaining non-legacy "consuming project" usage in active guidance.

Closes #51
