### PR TITLE
#71 Specify deterministic latest-tag resolution and ref validation

### DIFF
--- a/AGENTS_TEMPLATE.md
+++ b/AGENTS_TEMPLATE.md
@@ -26,7 +26,7 @@ Use this before any `git subtree add/pull` command:
   - If valid, set `REF=<TAG>`.
   - If invalid, stop and ask for a valid tag.
 - If the user explicitly asks for a branch, validate it:
-  `git ls-remote --exit-code --heads https://github.com/fabian-barney/ai-rules.git "<BRANCH>"`
+  `git ls-remote --exit-code --heads https://github.com/fabian-barney/ai-rules.git "refs/heads/<BRANCH>"`
   - If valid, set `REF=<BRANCH>`.
   - If invalid, stop and ask for a valid branch.
 - Otherwise resolve the latest tagged release:
@@ -34,11 +34,11 @@ Use this before any `git subtree add/pull` command:
   - If at least one `v*` tag exists, set `REF` to the last tag in the sorted output.
   - If no tags exist, set `REF=main`.
 - Before executing subtree commands, echo:
-  `Using ai-rules REF: <REF>`
+  Using ai-rules REF: `<REF>`
 
 ### Mode: local (no commits, no push)
 1. Add the ai-rules subtree (creates a local commit):
-   `git subtree add --prefix <AI_RULES_PATH> https://github.com/fabian-barney/ai-rules.git REF --squash`
+   `git subtree add --prefix <AI_RULES_PATH> https://github.com/fabian-barney/ai-rules.git <REF> --squash`
    - Resolve `REF` using the deterministic rules above.
    - If Git requires an author identity, set it locally:
      git config --local user.name "Your Name"
@@ -91,7 +91,7 @@ Local-only update note:
 
 ### Mode: git (tracked in repo)
 1. Add the ai-rules subtree:
-   `git subtree add --prefix <AI_RULES_PATH> https://github.com/fabian-barney/ai-rules.git REF --squash`
+   `git subtree add --prefix <AI_RULES_PATH> https://github.com/fabian-barney/ai-rules.git <REF> --squash`
    - Resolve `REF` using the deterministic rules above.
    - If Git requires an author identity, set it locally:
      git config --local user.name "Your Name"
@@ -130,7 +130,7 @@ Local-only update note:
 8. Commit and push the changes.
 
 Git update note:
-- Use `git subtree pull --prefix <AI_RULES_PATH> https://github.com/fabian-barney/ai-rules.git REF --squash`
+- Use `git subtree pull --prefix <AI_RULES_PATH> https://github.com/fabian-barney/ai-rules.git <REF> --squash`
   and commit the update.
 
 ## Entry Point Templates

--- a/AGENTS_TEMPLATE.md
+++ b/AGENTS_TEMPLATE.md
@@ -19,11 +19,27 @@ To switch modes later, use "mode ai-rules local" or "mode ai-rules git".
 ai-rules is vendored under `docs/ai/AI-RULES/`.
 Define `<AI_RULES_PATH>` as `docs/ai/AI-RULES`.
 
+### Resolve REF (deterministic)
+Use this before any `git subtree add/pull` command:
+- If the user specifies a tag (for example `v4.0.0`), validate it:
+  `git ls-remote --exit-code --refs --tags https://github.com/fabian-barney/ai-rules.git "refs/tags/<TAG>"`
+  - If valid, set `REF=<TAG>`.
+  - If invalid, stop and ask for a valid tag.
+- If the user explicitly asks for a branch, validate it:
+  `git ls-remote --exit-code --heads https://github.com/fabian-barney/ai-rules.git "<BRANCH>"`
+  - If valid, set `REF=<BRANCH>`.
+  - If invalid, stop and ask for a valid branch.
+- Otherwise resolve the latest tagged release:
+  `git ls-remote --refs --tags --sort="version:refname" https://github.com/fabian-barney/ai-rules.git "v*"`
+  - If at least one `v*` tag exists, set `REF` to the last tag in the sorted output.
+  - If no tags exist, set `REF=main`.
+- Before executing subtree commands, echo:
+  `Using ai-rules REF: <REF>`
+
 ### Mode: local (no commits, no push)
 1. Add the ai-rules subtree (creates a local commit):
    `git subtree add --prefix <AI_RULES_PATH> https://github.com/fabian-barney/ai-rules.git REF --squash`
-   - Use the requested version tag; otherwise use the latest tagged release.
-     If no tags exist, use `main`.
+   - Resolve `REF` using the deterministic rules above.
    - If Git requires an author identity, set it locally:
      git config --local user.name "Your Name"
      git config --local user.email "you@example.com"
@@ -76,8 +92,7 @@ Local-only update note:
 ### Mode: git (tracked in repo)
 1. Add the ai-rules subtree:
    `git subtree add --prefix <AI_RULES_PATH> https://github.com/fabian-barney/ai-rules.git REF --squash`
-   - Use the requested version tag; otherwise use the latest tagged release.
-     If no tags exist, use `main`.
+   - Resolve `REF` using the deterministic rules above.
    - If Git requires an author identity, set it locally:
      git config --local user.name "Your Name"
      git config --local user.email "you@example.com"

--- a/AI-RULES/UPDATE.md
+++ b/AI-RULES/UPDATE.md
@@ -30,7 +30,7 @@ Instructions for AI agents to update ai-rules in a downstream-project.
      - If the command fails, stop and ask for a valid tag.
      - If it succeeds, set `REF=<TAG>`.
    - If the user explicitly asks for a branch, validate it first:
-     `git ls-remote --exit-code --heads https://github.com/fabian-barney/ai-rules.git "<BRANCH>"`
+     `git ls-remote --exit-code --heads https://github.com/fabian-barney/ai-rules.git "refs/heads/<BRANCH>"`
      - If the command fails, stop and ask for a valid branch.
      - If it succeeds, set `REF=<BRANCH>`.
    - Otherwise resolve the latest tagged release:
@@ -38,10 +38,10 @@ Instructions for AI agents to update ai-rules in a downstream-project.
      - If at least one `v*` tag exists, set `REF` to the last tag in the sorted output.
      - If no tags exist, set `REF=main`.
    - Before any subtree command, echo the resolved ref to the user:
-     `Using ai-rules REF: <REF>`
+     Using ai-rules REF: `<REF>`
 4. Update based on mode:
    - If it is git (tracked subtree):
-     `git subtree pull --prefix "<AI_RULES_PATH>" https://github.com/fabian-barney/ai-rules.git REF --squash`
+     `git subtree pull --prefix "<AI_RULES_PATH>" https://github.com/fabian-barney/ai-rules.git <REF> --squash`
      Commit the update.
    - If it is local (no commits, no push):
      - Temporarily remove the ai-rules entries from `.git/info/exclude`.
@@ -50,7 +50,7 @@ Instructions for AI agents to update ai-rules in a downstream-project.
        `git config --local user.name "Your Name"`
        `git config --local user.email "you@example.com"`
      - Run:
-       `git subtree add --prefix "<AI_RULES_PATH>" https://github.com/fabian-barney/ai-rules.git REF --squash`
+       `git subtree add --prefix "<AI_RULES_PATH>" https://github.com/fabian-barney/ai-rules.git <REF> --squash`
        (This creates a commit.)
      - Undo the commit but keep files:
        `git reset --mixed HEAD~1`
@@ -100,9 +100,9 @@ Steps:
        treat it as user-specified and validate it before reuse.
      - If no reusable version is documented, resolve `REF` exactly as in update step 3.
    - Before any subtree command, echo the resolved ref to the user:
-     `Using ai-rules REF: <REF>`
+     Using ai-rules REF: `<REF>`
    - Run:
-     `git subtree add --prefix "<AI_RULES_PATH>" https://github.com/fabian-barney/ai-rules.git REF --squash`
+     `git subtree add --prefix "<AI_RULES_PATH>" https://github.com/fabian-barney/ai-rules.git <REF> --squash`
    - Create any missing entry points (for example `AGENTS.md` final references,
      `AI_PROJECT.md`, `CLAUDE.md`, and `.github/copilot-instructions.md`), ensure
      they are tracked, then commit and push.

--- a/AI-RULES/UPDATE.md
+++ b/AI-RULES/UPDATE.md
@@ -6,6 +6,23 @@ Instructions for AI agents to update ai-rules in a downstream-project.
 - "update ai-rules"
 - "update ai-rules v4.0.0"
 
+## REF Determination Rules
+Use these rules whenever a setup/update/mode-switch flow needs a `REF`.
+- If the user specifies a tag (for example `v4.0.0`), validate it first:
+  `git ls-remote --exit-code --refs --tags https://github.com/fabian-barney/ai-rules.git "refs/tags/<TAG>"`
+  - If the command fails, stop and ask for a valid tag.
+  - If it succeeds, set `REF=<TAG>`.
+- If the user explicitly asks for a branch, validate it first:
+  `git ls-remote --exit-code --heads https://github.com/fabian-barney/ai-rules.git "refs/heads/<BRANCH>"`
+  - If the command fails, stop and ask for a valid branch.
+  - If it succeeds, set `REF=<BRANCH>`.
+- Otherwise resolve the latest tagged release:
+  `git ls-remote --refs --tags --sort="version:refname" https://github.com/fabian-barney/ai-rules.git "v*"`
+  - If at least one `v*` tag exists, set `REF` to the last tag in the sorted output.
+  - If no tags exist, set `REF=main`.
+- Before any subtree command, echo the resolved ref to the user:
+  Using ai-rules REF: `<REF>`
+
 ## Update Steps (run when requested)
 1. Locate the vendored ai-rules path and entry point from `AGENTS.md` or README.
    - Set `<AI_RULES_PATH>` to the repo-relative path (for example `docs/ai/AI-RULES`).
@@ -24,21 +41,7 @@ Instructions for AI agents to update ai-rules in a downstream-project.
        /.github/copilot-instructions.md
      - If `git ls-files -- "<AI_RULES_PATH>/AI.md"` returns a tracked file, treat this as git mode.
      - If it is ambiguous, ask which mode to use.
-3. Determine `REF` deterministically:
-   - If the user specifies a tag (for example `v4.0.0`), validate it first:
-     `git ls-remote --exit-code --refs --tags https://github.com/fabian-barney/ai-rules.git "refs/tags/<TAG>"`
-     - If the command fails, stop and ask for a valid tag.
-     - If it succeeds, set `REF=<TAG>`.
-   - If the user explicitly asks for a branch, validate it first:
-     `git ls-remote --exit-code --heads https://github.com/fabian-barney/ai-rules.git "refs/heads/<BRANCH>"`
-     - If the command fails, stop and ask for a valid branch.
-     - If it succeeds, set `REF=<BRANCH>`.
-   - Otherwise resolve the latest tagged release:
-     `git ls-remote --refs --tags --sort="version:refname" https://github.com/fabian-barney/ai-rules.git "v*"`
-     - If at least one `v*` tag exists, set `REF` to the last tag in the sorted output.
-     - If no tags exist, set `REF=main`.
-   - Before any subtree command, echo the resolved ref to the user:
-     Using ai-rules REF: `<REF>`
+3. Determine `REF` using [REF Determination Rules](#ref-determination-rules).
 4. Update based on mode:
    - If it is git (tracked subtree):
      `git subtree pull --prefix "<AI_RULES_PATH>" https://github.com/fabian-barney/ai-rules.git <REF> --squash`
@@ -95,12 +98,11 @@ Steps:
      /CLAUDE.md
      /.github/copilot-instructions.md
    - If `<AI_RULES_PATH>` exists locally, remove it only after confirming there is no real work in it.
-   - Determine `REF` using the same deterministic rules from update step 3.
+   - Determine `REF` using [REF Determination Rules](#ref-determination-rules).
      - If the local ai-rules copy documents a version/tag (for example in `AGENTS.md`),
        treat it as user-specified and validate it before reuse.
-     - If no reusable version is documented, resolve `REF` exactly as in update step 3.
-   - Before any subtree command, echo the resolved ref to the user:
-     Using ai-rules REF: `<REF>`
+     - If no reusable version is documented, resolve `REF` with the default path
+       in REF Determination Rules (latest tagged release, fallback `main`).
    - Run:
      `git subtree add --prefix "<AI_RULES_PATH>" https://github.com/fabian-barney/ai-rules.git <REF> --squash`
    - Create any missing entry points (for example `AGENTS.md` final references,


### PR DESCRIPTION
## Summary\n- add deterministic REF resolution workflow for setup/update\n- define exact validation commands for user-specified tags and branches\n- define latest-tag resolution command, no-tag fallback (main), and mandatory REF echo before subtree operations\n\n## Files\n- AGENTS_TEMPLATE.md\n- AI-RULES/UPDATE.md\n\n## Validation\n- docs-only change reviewed for consistency and command correctness\n\nCloses #71