### PR TITLE
#66 Require target-version compatibility preflight before setup/update actions

### DIFF
--- a/AGENTS_TEMPLATE.md
+++ b/AGENTS_TEMPLATE.md
@@ -22,10 +22,13 @@ Define `<AI_RULES_PATH>` as `docs/ai/AI-RULES`.
 ### Target-version preflight (required)
 Before running any setup/update subtree command, inspect the target ai-rules
 version and adapt behavior as needed:
+- Use the same `REF` that will be passed to `git subtree add`/`git subtree pull`.
 - Read target-version docs:
   - `CHANGELOG.md`
   - `AI-RULES/UPDATE.md`
   - `AGENTS_TEMPLATE.md`
+- Inspect these files at `REF` using any reliable method (for example repository
+  web view, `git show`, or a temporary local checkout).
 - If the target version includes breaking or behavior-changing setup/update
   guidance, follow the target-version guidance even if it differs from this
   template.

--- a/AGENTS_TEMPLATE.md
+++ b/AGENTS_TEMPLATE.md
@@ -19,6 +19,19 @@ To switch modes later, use "mode ai-rules local" or "mode ai-rules git".
 ai-rules is vendored under `docs/ai/AI-RULES/`.
 Define `<AI_RULES_PATH>` as `docs/ai/AI-RULES`.
 
+### Target-version preflight (required)
+Before running any setup/update subtree command, inspect the target ai-rules
+version and adapt behavior as needed:
+- Read target-version docs:
+  - `CHANGELOG.md`
+  - `AI-RULES/UPDATE.md`
+  - `AGENTS_TEMPLATE.md`
+- If the target version includes breaking or behavior-changing setup/update
+  guidance, follow the target-version guidance even if it differs from this
+  template.
+- Summarize the detected differences and planned command changes before running
+  `git subtree add`/`git subtree pull`.
+
 ### Mode: local (no commits, no push)
 1. Add the ai-rules subtree (creates a local commit):
    `git subtree add --prefix <AI_RULES_PATH> https://github.com/fabian-barney/ai-rules.git REF --squash`

--- a/AI-RULES/UPDATE.md
+++ b/AI-RULES/UPDATE.md
@@ -33,13 +33,20 @@ Instructions for AI agents to update ai-rules in a downstream-project.
 4. Determine the target version (`TARGET_VERSION`):
    - If the user specifies a tag, use it.
    - Otherwise, use the latest tagged release.
+   - Set `REF=<TARGET_VERSION>` for subtree commands in this workflow.
 5. Run a compatibility preflight before any subtree command:
-   - Load and review target-version docs (from `TARGET_VERSION`):
+   - Load and review target-version docs at `REF` (the same ref used for subtree commands):
      - `CHANGELOG.md`
      - `AI-RULES/UPDATE.md`
      - `AGENTS_TEMPLATE.md`
-   - Review changelog entries for all versions between `CURRENT_VERSION` and
-     `TARGET_VERSION` (inclusive of intermediate versions).
+   - Use any reliable method to inspect these files at `REF` (for example the
+     repository web view, `git show`, or a temporary local checkout).
+   - Review changelog entries:
+     - If `CURRENT_VERSION` is known, review all versions after
+       `CURRENT_VERSION` up to and including `TARGET_VERSION` (including
+       intermediate versions).
+     - If `CURRENT_VERSION=unknown`, review all changelog entries up to and
+       including `TARGET_VERSION`.
    - Identify breaking or behavior-changing entries (for example path renames,
      entry-point changes, setup/update workflow changes, mode semantics changes).
    - Adapt the setup/update commands and file operations before execution.
@@ -48,7 +55,7 @@ Instructions for AI agents to update ai-rules in a downstream-project.
      to proceed instead of guessing.
 6. Update based on mode:
    - If it is git (tracked subtree):
-     `git subtree pull --prefix "<AI_RULES_PATH>" https://github.com/fabian-barney/ai-rules.git REF --squash`
+     `git subtree pull --prefix "<AI_RULES_PATH>" https://github.com/fabian-barney/ai-rules.git <REF> --squash`
      Commit the update.
    - If it is local (no commits, no push):
      - Temporarily remove the ai-rules entries from `.git/info/exclude`.
@@ -57,7 +64,7 @@ Instructions for AI agents to update ai-rules in a downstream-project.
        `git config --local user.name "Your Name"`
        `git config --local user.email "you@example.com"`
      - Run:
-       `git subtree add --prefix "<AI_RULES_PATH>" https://github.com/fabian-barney/ai-rules.git REF --squash`
+       `git subtree add --prefix "<AI_RULES_PATH>" https://github.com/fabian-barney/ai-rules.git <REF> --squash`
        (This creates a commit.)
      - Undo the commit but keep files:
        `git reset --mixed HEAD~1`
@@ -107,7 +114,7 @@ Steps:
        reuse that tag.
      - Otherwise, use the latest tagged release.
    - Run:
-     `git subtree add --prefix "<AI_RULES_PATH>" https://github.com/fabian-barney/ai-rules.git REF --squash`
+     `git subtree add --prefix "<AI_RULES_PATH>" https://github.com/fabian-barney/ai-rules.git <REF> --squash`
    - Create any missing entry points (for example `AGENTS.md` final references,
      `AI_PROJECT.md`, `CLAUDE.md`, and `.github/copilot-instructions.md`), ensure
      they are tracked, then commit and push.

--- a/AI-RULES/UPDATE.md
+++ b/AI-RULES/UPDATE.md
@@ -24,10 +24,29 @@ Instructions for AI agents to update ai-rules in a downstream-project.
        /.github/copilot-instructions.md
      - If `git ls-files -- "<AI_RULES_PATH>/AI.md"` returns a tracked file, treat this as git mode.
      - If it is ambiguous, ask which mode to use.
-3. Determine the target version:
+3. Determine the currently installed ai-rules version (`CURRENT_VERSION`):
+   - If the downstream-project explicitly tracks the installed ai-rules version,
+     reuse that value.
+   - Otherwise inspect `<AI_RULES_PATH>/CHANGELOG.md` and read the first
+     released version heading (`## [vX.Y.Z]`) as `CURRENT_VERSION`.
+   - If no version can be determined, set `CURRENT_VERSION=unknown`.
+4. Determine the target version (`TARGET_VERSION`):
    - If the user specifies a tag, use it.
    - Otherwise, use the latest tagged release.
-4. Update based on mode:
+5. Run a compatibility preflight before any subtree command:
+   - Load and review target-version docs (from `TARGET_VERSION`):
+     - `CHANGELOG.md`
+     - `AI-RULES/UPDATE.md`
+     - `AGENTS_TEMPLATE.md`
+   - Review changelog entries for all versions between `CURRENT_VERSION` and
+     `TARGET_VERSION` (inclusive of intermediate versions).
+   - Identify breaking or behavior-changing entries (for example path renames,
+     entry-point changes, setup/update workflow changes, mode semantics changes).
+   - Adapt the setup/update commands and file operations before execution.
+   - Summarize the detected changes and adapted execution plan before proceeding.
+   - If the target-version docs cannot be inspected, stop and ask the user how
+     to proceed instead of guessing.
+6. Update based on mode:
    - If it is git (tracked subtree):
      `git subtree pull --prefix "<AI_RULES_PATH>" https://github.com/fabian-barney/ai-rules.git REF --squash`
      Commit the update.
@@ -43,11 +62,11 @@ Instructions for AI agents to update ai-rules in a downstream-project.
      - Undo the commit but keep files:
        `git reset --mixed HEAD~1`
      - Re-add the exclude entries to `.git/info/exclude`.
-5. Verify the baseline entry point still resolves (e.g., `<AI_RULES_PATH>/AI.md`).
-6. Preserve local overlays and any project-specific rules outside the vendor path,
+7. Verify the baseline entry point still resolves (e.g., `<AI_RULES_PATH>/AI.md`).
+8. Preserve local overlays and any project-specific rules outside the vendor path,
    including `docs/ai/LESSONS_LEARNED/` if used.
-7. Record the updated version in the destination repository if it tracks versions.
-8. Summarize changes.
+9. Record the updated version in the destination repository if it tracks versions.
+10. Summarize changes.
 
 ## Mode Switch (when requested)
 Prompt Examples:


### PR DESCRIPTION
## Summary\n- add explicit current-version and target-version determination to update flow\n- require a compatibility preflight phase before any subtree command\n- require review of target CHANGELOG.md, AI-RULES/UPDATE.md, and AGENTS_TEMPLATE.md\n- require review of intermediate releases and adaptation of commands before execution\n\n## Files\n- AI-RULES/UPDATE.md\n- AGENTS_TEMPLATE.md\n\n## Validation\n- docs-only change reviewed against issue acceptance criteria\n\nCloses #66