### PR TITLE
#67 Harden setup-mode auto-detection for mixed repository states

### DIFF
--- a/AGENTS_TEMPLATE.md
+++ b/AGENTS_TEMPLATE.md
@@ -97,7 +97,7 @@ Local-only update note:
      after explicit confirmation (for example, `git reset --hard`).
 2. Baseline entry point (after subtree add):
    `<AI_RULES_PATH>/AI.md`
-3. Create a local overlay for project-specific rules (recommended):
+3. Create a project overlay for project-specific rules (recommended):
    AI_PROJECT.md
    Note: keep this outside `docs/ai/` so subtree updates do not overwrite it.
    In git mode, keep `AI_PROJECT.md` tracked so the team shares the overlay.

--- a/AGENTS_TEMPLATE.md
+++ b/AGENTS_TEMPLATE.md
@@ -53,6 +53,7 @@ Define `<AI_RULES_PATH>` as `docs/ai/AI-RULES`.
 5. Create a local overlay for project-specific rules (recommended):
    AI_PROJECT.md
    Note: keep this outside `docs/ai/` so subtree updates do not overwrite it.
+   In local mode, keep `AI_PROJECT.md` local-only (excluded from VCS).
 6. Create a project lessons learned area (recommended):
    docs/ai/LESSONS_LEARNED/LESSONS_LEARNED.md
    See `AI-RULES/DOWNSTREAM-PROJECT.md` for guidance.
@@ -99,6 +100,7 @@ Local-only update note:
 3. Create a local overlay for project-specific rules (recommended):
    AI_PROJECT.md
    Note: keep this outside `docs/ai/` so subtree updates do not overwrite it.
+   In git mode, keep `AI_PROJECT.md` tracked so the team shares the overlay.
 4. Create a project lessons learned area (recommended):
    docs/ai/LESSONS_LEARNED/LESSONS_LEARNED.md
    See `AI-RULES/DOWNSTREAM-PROJECT.md` for guidance.

--- a/AI-RULES/UPDATE.md
+++ b/AI-RULES/UPDATE.md
@@ -16,13 +16,12 @@ Instructions for AI agents to update ai-rules in a downstream-project.
    - If the user explicitly specifies a mode, use it.
    - Otherwise auto-detect using both repository signals:
      - `TRACKED_SUBTREE=true` if `git ls-files -- "<AI_RULES_PATH>/AI.md"` returns a tracked file.
-     - `LOCAL_HINT=true` if `.git/info/exclude` contains any of these entries
-       (replace `/<AI_RULES_PATH>/` with the real path; example: `/docs/ai/AI-RULES/`):
-       /<AI_RULES_PATH>/
-       /AGENTS.md
-       /AI_PROJECT.md
-       /CLAUDE.md
-       /.github/copilot-instructions.md
+     - `LOCAL_HINT=true` if `.git/info/exclude` contains the subtree directory
+       entry `/<AI_RULES_PATH>/` (replace with the real path; example:
+       `/docs/ai/AI-RULES/`).
+       Companion excludes (for example `/AGENTS.md`, `/AI_PROJECT.md`,
+       `/CLAUDE.md`, `/.github/copilot-instructions.md`) are optional and do not
+       affect `LOCAL_HINT`.
    - Resolve mode from combined signals:
      - `TRACKED_SUBTREE=true` and `LOCAL_HINT=false` => git mode.
      - `TRACKED_SUBTREE=false` and `LOCAL_HINT=true` => local mode.


### PR DESCRIPTION
## Summary\n- replace single-signal mode detection with combined-signal resolution (TRACKED_SUBTREE + LOCAL_HINT)\n- define explicit ambiguous-state handling instead of implicit local inference\n- document explicit AI_PROJECT.md behavior by mode (local-only in local mode, tracked/shared in git mode)\n\n## Files\n- AI-RULES/UPDATE.md\n- AGENTS_TEMPLATE.md\n\n## Validation\n- docs-only change reviewed against issue acceptance criteria\n\nCloses #67