### PR TITLE
#64 Define workflow for evaluating and handling PR/MR review comments

### DIFF
--- a/CORE/VERSION_CONTROL_SYSTEM.md
+++ b/CORE/VERSION_CONTROL_SYSTEM.md
@@ -31,6 +31,23 @@ Guidance for version control system usage (Git and others).
 - If you have access to the issue tracker, add that summary directly to the
   linked issue/ticket.
 
+## PR/MR Review Comment Handling
+- Evaluate every review comment and explicitly judge whether it is valid or not
+  for the current scope.
+- Reply to every review comment with a respectful, concrete response. Do not
+  leave actionable comments unanswered.
+- If the comment is valid:
+  - Apply a fix in the same PR/MR when appropriate.
+  - If not fixed immediately, create or link a follow-up issue/ticket and
+    explain why deferral is acceptable.
+- If the comment is not valid, explain the reasoning with project-specific
+  context and keep the tone factual and professional.
+- Resolve/close review comments when appropriate, but first check downstream
+  project rules for ownership (for example whether the author or reviewer is
+  expected to mark comments resolved).
+- Do not resolve/close comments by deleting discussion; keep decisions auditable
+  in the comment thread.
+
 ### PR/MR Summary Template (Code Reviewer Audience)
 ```md
 ## Implementation Summary

--- a/CORE/VERSION_CONTROL_SYSTEM.md
+++ b/CORE/VERSION_CONTROL_SYSTEM.md
@@ -42,11 +42,11 @@ Guidance for version control system usage (Git and others).
     explain why deferral is acceptable.
 - If the comment is not valid, explain the reasoning with project-specific
   context and keep the tone factual and professional.
-- Resolve/close review comments when appropriate, but first check downstream
-  project rules for ownership (for example whether the author or reviewer is
-  expected to mark comments resolved).
-- Do not resolve/close comments by deleting discussion; keep decisions auditable
-  in the comment thread.
+- When appropriate, mark the relevant review thread or conversation as resolved,
+  but first check downstream project rules for ownership (for example whether
+  the author or reviewer is expected to mark threads resolved).
+- Do not mark a review thread or conversation resolved by deleting discussion;
+  keep decisions auditable in the comment thread.
 
 ### PR/MR Summary Template (Code Reviewer Audience)
 ```md


### PR DESCRIPTION
## Summary\n- add explicit PR/MR review comment handling workflow to VCS guidance\n- require per-comment validity judgment and respectful response on every comment\n- define fix-now vs follow-up-ticket decision for valid comments\n- add explicit resolution/closure ownership check against downstream project rules\n- require auditable discussion (no deletion-based resolution)\n\n## Files\n- CORE/VERSION_CONTROL_SYSTEM.md\n\n## Validation\n- docs-only change reviewed against issue acceptance criteria\n\nCloses #64