### PR TITLE
docs: fix Java entry-point link

### DIFF
--- a/LANGUAGE/JAVA/JAVA.md
+++ b/LANGUAGE/JAVA/JAVA.md
@@ -1,7 +1,7 @@
 # JAVA
 
 ## Entry Point
-- `EFFECTIVE_JAVA.md` - distilled ruleset for Java code quality.
+- [EFFECTIVE_JAVA.md](EFFECTIVE_JAVA.md) - distilled ruleset for Java code quality.
 
 ## General Java Rules (summary)
 - Prefer immutability where practical.


### PR DESCRIPTION
## Summary
- convert LANGUAGE/JAVA/JAVA.md entry-point reference to a proper markdown link
- ensure EFFECTIVE_JAVA.md is directly clickable from JAVA.md
- run a repo-wide markdown relative-link scan for additional missing links

## Validation
- markdown relative-link scan result: MISSING_COUNT=0

Closes #79