### PR TITLE
#92 Refine LANGUAGE index contract and inheritance boundaries

### DIFF
--- a/LANGUAGE/LANGUAGE.md
+++ b/LANGUAGE/LANGUAGE.md
@@ -1,11 +1,48 @@
 # LANGUAGE
 
-Language-specific rule sets live in subdirectories.
+Language-layer contract for syntax, semantics, naming, and readability rules.
+
+## Role in the Ruleset
+- LANGUAGE sits between cross-cutting baseline docs and framework/library docs.
+- Frameworks and libraries inherit language constraints before applying their
+  own specialization.
+- Global precedence and override semantics are defined in
+  `CORE/RULE_DEPENDENCY_TREE.md`.
+
+## Scope Boundary
+LANGUAGE includes:
+- Language-agnostic coding conventions and readability constraints.
+- Language-specific defaults and pitfalls (for example Java, TypeScript).
+- Language-level naming/casing and typing rules.
+
+LANGUAGE does not include:
+- Framework lifecycle or rendering behavior.
+- Library API usage rules.
+- Build, deployment, or CI runtime behavior.
+
+Those belong in `FRAMEWORK/**`, `LIBRARY/**`, `BUILD_TOOLS/**`,
+`INFRASTRUCTURE/**`, and `CI-CD/**`.
+
+## Inheritance and Specialization Contract
+- Apply `CONVENTIONS.md` and `READABILITY.md` to all languages by default.
+- Apply the specific language document next (for example Java or TypeScript).
+- If a specialized language extends another language model (for example
+  TypeScript over JavaScript), the specialization may narrow rules but must not
+  silently weaken inherited correctness/safety constraints.
+- Framework docs may specialize language usage patterns, but only with explicit
+  rationale in that framework doc.
 
 ## Files
 - [CONVENTIONS.md](CONVENTIONS.md) - General coding conventions.
 - [READABILITY.md](READABILITY.md) - Readability and clarity guidance.
 
 ## Languages
-- [JAVA/JAVA.md](JAVA/JAVA.md) - Java rules and entry point
-- [TYPESCRIPT/TYPESCRIPT.md](TYPESCRIPT/TYPESCRIPT.md) - TypeScript rules and entry point
+- [JAVA/JAVA.md](JAVA/JAVA.md) - Java language baseline and entry point.
+- [TYPESCRIPT/TYPESCRIPT.md](TYPESCRIPT/TYPESCRIPT.md) - TypeScript baseline
+  and JavaScript specialization entry point.
+
+## Authoring Notes
+- Keep this file index-level and boundary-focused.
+- Put deep language behavior in language-specific docs, not here.
+- When adding a new language, add it to this index and align semantic
+  dependencies in `CORE/RULE_DEPENDENCY_TREE.md`.


### PR DESCRIPTION
Closes #92
Part of #87

## Implementation Summary
- Scope:
  - Refined `LANGUAGE/LANGUAGE.md` as a semantic language-layer contract index.
- Key changes:
  - Added explicit role of language layer in precedence and inheritance.
  - Added clear scope boundary between language rules and framework/library/tool
    rules.
  - Added specialization contract (including typed-over-base language behavior).
  - Kept this document index-level while improving operational guidance.
- Non-goals:
  - No child language-doc rewrites in this PR.

## Validation
- Tests executed:
  - `npx --yes markdownlint-cli2 LANGUAGE/LANGUAGE.md`
- Manual checks:
  - Verified dependency reference to `CORE/RULE_DEPENDENCY_TREE.md`.
- Residual risks:
  - Child language docs still need phased deepening aligned with this index.
