### PR TITLE
#94 Refine FRAMEWORK index contract and specialization boundaries

### DIFF
--- a/FRAMEWORK/FRAMEWORK.md
+++ b/FRAMEWORK/FRAMEWORK.md
@@ -1,10 +1,36 @@
 # FRAMEWORK
 
-Place framework-specific rules in this directory.
+Framework-layer contract for runtime and UI/application framework behavior.
 
-## General Rule
-- Follow framework architectural conventions by default. Deviations require a
-  clear rationale and, if material, an ADR.
+## Role in the Ruleset
+- FRAMEWORK docs specialize language and architecture rules for concrete
+  framework ecosystems.
+- Framework docs inherit cross-cutting and language baselines before adding
+  framework-specific patterns.
+- Global precedence and override behavior are defined in
+  `CORE/RULE_DEPENDENCY_TREE.md`.
+
+## Scope Boundary
+FRAMEWORK includes:
+- Framework lifecycle and state-management guidance.
+- Framework-specific performance, testing, and SSR/hydration patterns.
+- Framework-specific pitfalls and code review checklists.
+
+FRAMEWORK does not include:
+- Generic language conventions and readability rules.
+- Generic library API usage rules.
+- Build/deployment/CI implementation details.
+
+Those belong in `LANGUAGE/**`, `LIBRARY/**`, `BUILD_TOOLS/**`,
+`INFRASTRUCTURE/**`, and `CI-CD/**`.
+
+## Specialization Contract
+- Framework docs may narrow language-level guidance when framework semantics
+  require it.
+- Any framework-level override must be explicit and justified in the framework
+  document.
+- Framework docs must not silently weaken cross-cutting security/compliance/test
+  constraints.
 
 ## Selection Guidance
 - Prefer mature, enterprise-ready frameworks with a proven track record.
@@ -25,3 +51,9 @@ Place framework-specific rules in this directory.
 - [SPRING_BOOT.md](SPRING_BOOT.md) - Spring Boot guidance.
 - [SVELTE.md](SVELTE.md) - Svelte framework guidance.
 - [TAILWIND_CSS.md](TAILWIND_CSS.md) - Tailwind CSS guidance.
+
+## Authoring Notes
+- Keep this file index-level and boundary-focused.
+- Put deep framework behavior in child framework documents.
+- When adding a new framework doc, update this index and align semantic
+  dependencies in `CORE/RULE_DEPENDENCY_TREE.md`.


### PR DESCRIPTION
Closes #94
Part of #87

## Implementation Summary
- Scope:
  - Refined `FRAMEWORK/FRAMEWORK.md` as framework-layer contract index.
- Key changes:
  - Added framework-layer role in semantic precedence and inheritance.
  - Added explicit boundary vs language/library/build/infra domains.
  - Added specialization/override contract for framework docs.
  - Preserved and retained framework selection guidance and child index map.
- Non-goals:
  - No deep rewrites of child framework docs in this PR.

## Validation
- Tests executed:
  - `npx --yes markdownlint-cli2 FRAMEWORK/FRAMEWORK.md`
- Manual checks:
  - Verified alignment with `CORE/RULE_DEPENDENCY_TREE.md`.
- Residual risks:
  - Child framework docs still require phased deepening under the updated
    contract.
