### PR TITLE
#98 Refine BUILD_TOOLS index contract and boundaries

### DIFF
--- a/BUILD_TOOLS/BUILD_TOOLS.md
+++ b/BUILD_TOOLS/BUILD_TOOLS.md
@@ -1,12 +1,45 @@
 # BUILD_TOOLS
 
-Build and dependency management rules live in this directory.
+Build-tool layer contract for dependency management, build reproducibility, and
+artifact-generation workflow.
 
-## General Rule
-- Prefer the standard build tool for the language/ecosystem unless there is a clear reason to deviate.
+## Role in the Ruleset
+- BUILD_TOOLS docs specialize how projects resolve dependencies, build
+  artifacts, and enforce reproducible tooling behavior.
+- Build-tool guidance inherits cross-cutting and language constraints first, and
+  then adds tool-specific workflow rules.
+- Global precedence and override behavior are defined in
+  `CORE/RULE_DEPENDENCY_TREE.md`.
+
+## Scope Boundary
+BUILD_TOOLS includes:
+- Package/dependency manager behavior and lock-file strategy.
+- Build lifecycle, wrapper/runtime pinning, and deterministic installs.
+- Tool-specific CI integration constraints for dependency/build phases.
+
+BUILD_TOOLS does not include:
+- Framework runtime architecture/lifecycle behavior.
+- Library API usage patterns.
+- Deployment/runtime infrastructure behavior.
+
+Those belong in `FRAMEWORK/**`, `LIBRARY/**`, `INFRASTRUCTURE/**`, and
+`CI-CD/**`.
+
+## Specialization Contract
+- Prefer the standard build tool for the language/ecosystem unless a strong,
+  explicit reason exists to deviate.
+- Tool-specific docs may narrow parent guidance when tool semantics require it.
+- Tool docs must not weaken inherited security/compliance/reproducibility
+  constraints without explicit rationale.
 
 ## Files
 - [BUN.md](BUN.md) - Bun package manager guidance.
 - [GRADLE.md](GRADLE.md) - Gradle build and wrapper guidance.
 - [MAVEN.md](MAVEN.md) - Maven build and wrapper guidance.
 - [NPM.md](NPM.md) - Node.js package manager guidance (npm, Yarn, pnpm).
+
+## Authoring Notes
+- Keep this file index-level and boundary-focused.
+- Put deep tool behavior in child tool docs.
+- When adding a new build-tool doc, update this index and align dependencies in
+  `CORE/RULE_DEPENDENCY_TREE.md`.


### PR DESCRIPTION
Closes #98
Part of #87

## Implementation Summary
- Scope:
  - Refined `BUILD_TOOLS/BUILD_TOOLS.md` as build-tool layer contract index.
- Key changes:
  - Added build-tool role in semantic precedence and inheritance.
  - Added boundary vs framework/library/infra concerns.
  - Added specialization contract for tool-specific docs.
  - Preserved child tool index map.
- Non-goals:
  - No deep rewrites of child tool docs in this PR.

## Validation
- Tests executed:
  - `npx --yes markdownlint-cli2 BUILD_TOOLS/BUILD_TOOLS.md`
- Manual checks:
  - Verified alignment with `CORE/RULE_DEPENDENCY_TREE.md`.
- Residual risks:
  - Child tool docs still require phased deep rewrites.
