### PR TITLE
#100 Refine ARCHITECTURE index contract and boundaries

### DIFF
--- a/ARCHITECTURE/ARCHITECTURE.md
+++ b/ARCHITECTURE/ARCHITECTURE.md
@@ -1,6 +1,37 @@
 # ARCHITECTURE
 
-Place architecture rules in this directory.
+Architecture-layer contract for system design, boundaries, and interaction
+patterns.
+
+## Role in the Ruleset
+- ARCHITECTURE docs define structural constraints that guide implementation in
+  frameworks and libraries.
+- Architecture guidance inherits cross-cutting and language baselines and then
+  adds system-level design rules.
+- Global precedence and override behavior are defined in
+  `CORE/RULE_DEPENDENCY_TREE.md`.
+
+## Scope Boundary
+ARCHITECTURE includes:
+- Service/system boundaries and dependency direction.
+- API style and integration pattern constraints.
+- Architecture-level performance/resilience and consistency guardrails.
+
+ARCHITECTURE does not include:
+- Framework lifecycle/state/rendering details.
+- Library API-level coding guidance.
+- Build/deploy/runtime infrastructure procedures.
+
+Those belong in `FRAMEWORK/**`, `LIBRARY/**`, `BUILD_TOOLS/**`,
+`INFRASTRUCTURE/**`, and `CI-CD/**`.
+
+## Specialization Contract
+- Pattern documents may specialize architecture constraints for specific styles
+  (for example event-driven, REST, GraphQL).
+- Architecture docs must not weaken inherited security/compliance/test
+  constraints without explicit rationale.
+- Framework/library docs may specialize architecture guidance only with explicit
+  justification in those specialized docs.
 
 ## Files
 - [CLEAN_ARCHITECTURE.md](CLEAN_ARCHITECTURE.md) - Layering and dependency direction guidance.
@@ -10,3 +41,9 @@ Place architecture rules in this directory.
 - [MICROSERVICE.md](MICROSERVICE.md) - Microservice architecture practices.
 - [N_PLUS_1.md](N_PLUS_1.md) - Prevent N+1 query patterns.
 - [REST.md](REST.md) - REST API design rules.
+
+## Authoring Notes
+- Keep this file index-level and boundary-focused.
+- Put deep pattern behavior in child architecture docs.
+- When adding a new architecture doc, update this index and align semantic
+  dependencies in `CORE/RULE_DEPENDENCY_TREE.md`.


### PR DESCRIPTION
Closes #100
Part of #87

## Implementation Summary
- Scope:
  - Refined `ARCHITECTURE/ARCHITECTURE.md` as architecture-layer contract index.
- Key changes:
  - Added architecture-layer role in semantic precedence and inheritance.
  - Added explicit boundary vs framework/library/build/infra concerns.
  - Added specialization contract for pattern docs.
  - Preserved child architecture map.
- Non-goals:
  - No deep rewrites of child architecture docs in this PR.

## Validation
- Tests executed:
  - `npx --yes markdownlint-cli2 ARCHITECTURE/ARCHITECTURE.md`
- Manual checks:
  - Verified alignment with `CORE/RULE_DEPENDENCY_TREE.md`.
- Residual risks:
  - Child architecture docs still require phased deep rewrites.
