### PR TITLE
#102 Refine INFRASTRUCTURE index contract and boundaries

### DIFF
--- a/INFRASTRUCTURE/INFRASTRUCTURE.md
+++ b/INFRASTRUCTURE/INFRASTRUCTURE.md
@@ -1,9 +1,45 @@
 # INFRASTRUCTURE
 
-Platform and runtime infrastructure guidance.
+Infrastructure-layer contract for runtime environment, deployment topology, and
+platform operations behavior.
+
+## Role in the Ruleset
+- INFRASTRUCTURE docs specialize how applications are packaged, deployed, and
+  operated in target environments.
+- Infrastructure guidance inherits cross-cutting, language, architecture, and
+  build-tool constraints before adding platform-specific rules.
+- Global precedence and override behavior are defined in
+  `CORE/RULE_DEPENDENCY_TREE.md`.
+
+## Scope Boundary
+INFRASTRUCTURE includes:
+- Container/runtime platform configuration and deployment strategies.
+- Cluster/service-mesh operational constraints.
+- Infrastructure-level reliability, observability, and security posture.
+
+INFRASTRUCTURE does not include:
+- Framework lifecycle/state/rendering guidance.
+- Library API usage behavior.
+- Source-level language coding conventions.
+
+Those belong in `FRAMEWORK/**`, `LIBRARY/**`, and `LANGUAGE/**`.
+
+## Specialization Contract
+- Infrastructure child docs may narrow parent guidance where runtime semantics
+  require it.
+- Infrastructure docs must not weaken inherited security/compliance/test
+  constraints without explicit, reviewed rationale.
+- CI/CD docs may specialize delivery automation around infrastructure rules but
+  must keep this layer authoritative for runtime platform behavior.
 
 ## Files
 - [DOCKER.md](DOCKER.md) - Containerization guidance.
 - [KUBERNETES.md](KUBERNETES.md) - Kubernetes deployment guidance.
 - [HELM.md](HELM.md) - Helm chart practices.
 - [ISTIO.md](ISTIO.md) - Service mesh guidance.
+
+## Authoring Notes
+- Keep this file index-level and boundary-focused.
+- Put deep platform behavior in child infrastructure docs.
+- When adding a new infrastructure doc, update this index and align semantic
+  dependencies in `CORE/RULE_DEPENDENCY_TREE.md`.


### PR DESCRIPTION
Closes #102
Part of #87

## Implementation Summary
- Scope:
  - Refined `INFRASTRUCTURE/INFRASTRUCTURE.md` as infrastructure-layer contract
    index.
- Key changes:
  - Added infrastructure-layer role in semantic precedence/inheritance.
  - Added explicit scope boundary vs framework/library/language concerns.
  - Added specialization contract for child infrastructure docs.
  - Preserved child infrastructure index map.
- Non-goals:
  - No deep rewrites of child infrastructure docs in this PR.

## Validation
- Tests executed:
  - `npx --yes markdownlint-cli2 INFRASTRUCTURE/INFRASTRUCTURE.md`
- Manual checks:
  - Verified alignment with `CORE/RULE_DEPENDENCY_TREE.md`.
- Residual risks:
  - Child infrastructure docs still need phased deep rewrites.
