### PR TITLE
#104 Refine CI-CD index contract and boundaries

### DIFF
--- a/CI-CD/CI-CD.md
+++ b/CI-CD/CI-CD.md
@@ -1,6 +1,43 @@
 # CI-CD
 
-Continuous integration and delivery guidance.
+CI/CD-layer contract for automation of build, test, verification, and delivery
+pipelines.
+
+## Role in the Ruleset
+- CI/CD docs specialize how quality gates and delivery workflows are automated
+  across environments.
+- CI/CD guidance inherits cross-cutting, language, build-tool, and
+  infrastructure constraints before adding pipeline-specific rules.
+- Global precedence and override behavior are defined in
+  `CORE/RULE_DEPENDENCY_TREE.md`.
+
+## Scope Boundary
+CI/CD includes:
+- Pipeline stage structure and gating strategy.
+- Artifact/report publishing and release automation constraints.
+- CI secret handling and pipeline-level observability expectations.
+
+CI/CD does not include:
+- Source-level language/framework/library coding rules.
+- Deep dependency manager behavior details.
+- Runtime platform deployment semantics.
+
+Those belong in `LANGUAGE/**`, `FRAMEWORK/**`, `LIBRARY/**`,
+`BUILD_TOOLS/**`, and `INFRASTRUCTURE/**`.
+
+## Specialization Contract
+- Provider-specific CI/CD docs may narrow parent CI/CD guidance where platform
+  semantics require it.
+- CI/CD docs must not weaken inherited security/compliance/test constraints
+  without explicit, reviewed rationale.
+- Build-tool and infrastructure docs remain authoritative for their own layers;
+  CI/CD docs should orchestrate them rather than redefine them.
 
 ## Files
 - [GITLAB.md](GITLAB.md) - GitLab CI/CD pipeline guidance.
+
+## Authoring Notes
+- Keep this file index-level and boundary-focused.
+- Put deep pipeline implementation behavior in provider-specific child docs.
+- When adding a CI/CD provider doc, update this index and align semantic
+  dependencies in `CORE/RULE_DEPENDENCY_TREE.md`.


### PR DESCRIPTION
Closes #104
Part of #87

## Implementation Summary
- Scope:
  - Refined `CI-CD/CI-CD.md` as CI/CD-layer contract index.
- Key changes:
  - Added CI/CD layer role in semantic precedence/inheritance.
  - Added explicit boundary vs language/framework/library/build/infra concerns.
  - Added specialization contract for provider-specific CI docs.
  - Preserved child CI/CD index map.
- Non-goals:
  - No deep rewrite of provider-specific CI docs in this PR.

## Validation
- Tests executed:
  - `npx --yes markdownlint-cli2 CI-CD/CI-CD.md`
- Manual checks:
  - Verified alignment with `CORE/RULE_DEPENDENCY_TREE.md`.
- Residual risks:
  - Child CI/CD docs still need phased deep rewrites.
