### PR TITLE
#106 Refine DESIGN index contract and boundaries

### DIFF
--- a/DESIGN/DESIGN.md
+++ b/DESIGN/DESIGN.md
@@ -1,9 +1,46 @@
 # DESIGN
 
-Place design and code-quality rules in this directory.
+Design-principles layer contract for maintainability, cohesion, coupling, and
+long-term code quality.
+
+## Role in the Ruleset
+- DESIGN docs define principle-level constraints that shape implementation
+  choices across languages, frameworks, and libraries.
+- Design guidance inherits cross-cutting and language baselines and adds
+  structure-oriented quality rules.
+- Global precedence and override behavior are defined in
+  `CORE/RULE_DEPENDENCY_TREE.md`.
+
+## Scope Boundary
+DESIGN includes:
+- Principle-level guidance for structure, readability, and complexity control.
+- Reusable pattern guidance independent of specific frameworks/tools.
+- Tradeoff guidance for modularity, extensibility, and maintainability.
+
+DESIGN does not include:
+- Framework lifecycle/runtime behavior.
+- Library API-specific usage details.
+- Build/deployment/runtime platform procedures.
+
+Those belong in `FRAMEWORK/**`, `LIBRARY/**`, `BUILD_TOOLS/**`,
+`INFRASTRUCTURE/**`, and `CI-CD/**`.
+
+## Specialization Contract
+- Child design docs may narrow design principles for specific contexts
+  (for example SOLID, GoF patterns, AOP boundaries).
+- Design docs must not weaken inherited security/compliance/test constraints
+  without explicit, reviewed rationale.
+- Framework/library docs may apply design patterns concretely, but design
+  principles remain authoritative unless explicitly specialized.
 
 ## Files
 - [AOP.md](AOP.md) - Aspect-oriented programming guidance.
 - [CLEAN_CODE.md](CLEAN_CODE.md) - Clean code practices.
 - [GOF_DESIGN_PATTERNS.md](GOF_DESIGN_PATTERNS.md) - Gang of Four design pattern guidance.
 - [SOLID.md](SOLID.md) - SOLID principles guidance.
+
+## Authoring Notes
+- Keep this file index-level and boundary-focused.
+- Put deep principle and pattern behavior in child design docs.
+- When adding a design doc, update this index and align semantic dependencies
+  in `CORE/RULE_DEPENDENCY_TREE.md`.


### PR DESCRIPTION
Closes #106
Part of #87

## Implementation Summary
- Scope:
  - Refined `DESIGN/DESIGN.md` as design-principles layer contract index.
- Key changes:
  - Added design layer role in semantic precedence/inheritance.
  - Added explicit boundary vs framework/library/build/infra concerns.
  - Added specialization contract for child design docs.
  - Preserved child design index map.
- Non-goals:
  - No deep rewrites of child design docs in this PR.

## Validation
- Tests executed:
  - `npx --yes markdownlint-cli2 DESIGN/DESIGN.md`
- Manual checks:
  - Verified alignment with `CORE/RULE_DEPENDENCY_TREE.md`.
- Residual risks:
  - Child design docs still need phased deep rewrites.
