### PR TITLE
#110 Refine COMPLIANCE index contract and boundaries

### DIFF
--- a/COMPLIANCE/COMPLIANCE.md
+++ b/COMPLIANCE/COMPLIANCE.md
@@ -1,6 +1,44 @@
 # COMPLIANCE
 
-Compliance and governance rules live in this directory.
+Compliance-layer contract for legal, licensing, and governance constraints that
+must be preserved across all technology choices.
+
+## Role in the Ruleset
+- COMPLIANCE defines non-negotiable legal/governance constraints for dependency
+  selection and delivery artifacts.
+- Compliance guidance is inherited by all language, framework, library, build,
+  infrastructure, and CI/CD docs.
+- Global precedence and override behavior are defined in
+  `CORE/RULE_DEPENDENCY_TREE.md`.
+
+## Scope Boundary
+COMPLIANCE includes:
+- License compatibility constraints.
+- Attribution and third-party notice obligations.
+- Governance expectations that affect technology selection and distribution.
+
+COMPLIANCE does not include:
+- API-level coding guidance.
+- Framework runtime behavior.
+- Build/pipeline implementation details, except where needed for compliance
+  enforcement.
+
+Those belong in `LANGUAGE/**`, `FRAMEWORK/**`, `LIBRARY/**`,
+`BUILD_TOOLS/**`, `INFRASTRUCTURE/**`, and `CI-CD/**`.
+
+## Specialization Contract
+- Child compliance docs may narrow compliance constraints for specific legal
+  domains (for example license policy).
+- Downstream docs must not weaken compliance constraints without explicit,
+  reviewed governance approval.
+- If a technical recommendation conflicts with compliance rules, compliance is
+  authoritative and the technical guidance must be revised.
 
 ## Files
 - [LICENSES.md](LICENSES.md) - License compliance and allowed licenses.
+
+## Authoring Notes
+- Keep this file index-level and boundary-focused.
+- Put deep legal/policy specifics in child compliance docs.
+- When adding compliance docs, update this index and align semantic dependencies
+  in `CORE/RULE_DEPENDENCY_TREE.md`.


### PR DESCRIPTION
Closes #110
Part of #87

## Implementation Summary
- Scope:
  - Refined `COMPLIANCE/COMPLIANCE.md` as compliance-layer contract index.
- Key changes:
  - Added compliance layer role in semantic precedence/inheritance.
  - Added explicit boundary vs implementation/framework/library/build/infra
    details.
  - Added specialization contract for child compliance docs.
  - Preserved child compliance index map.
- Non-goals:
  - No deep rewrite of `COMPLIANCE/LICENSES.md` in this PR.

## Validation
- Tests executed:
  - `npx --yes markdownlint-cli2 COMPLIANCE/COMPLIANCE.md`
- Manual checks:
  - Verified alignment with `CORE/RULE_DEPENDENCY_TREE.md`.
- Residual risks:
  - `COMPLIANCE/LICENSES.md` still needs phased deep rewrite alignment.
