### PR TITLE
Deepen Effective Java guidance

### DIFF
--- a/LANGUAGE/JAVA/EFFECTIVE_JAVA.md
+++ b/LANGUAGE/JAVA/EFFECTIVE_JAVA.md
@@ -1,29 +1,130 @@
 # EFFECTIVE_JAVA
 
-This file is a concise, non-exhaustive ruleset inspired by Effective Java. It is
-meant to guide reviews and implementations without quoting the book.
+Guidance for AI agents applying Effective-Java-style decisions in modern Java
+codebases.
 
-## Core Principles
-- Prefer immutability; keep fields `final` where possible.
-- Minimize mutability exposure; avoid returning internal mutable state.
-- Favor static factories over constructors when they improve clarity.
-- Use builders for constructors with many parameters.
-- Prefer interfaces over concrete implementations in public APIs.
-- Override `equals`, `hashCode`, and `toString` together when identity semantics
-  matter.
-- Use `Optional` for absent return values; avoid returning `null` from APIs.
-- Fail fast with clear exceptions; validate arguments early.
-- Make defensive copies of mutable inputs.
-- Prefer composition over inheritance unless the subtype truly is-a supertype.
+## Scope
+- Specialize `LANGUAGE/JAVA/JAVA.md` with higher-signal Java design heuristics.
+- Use this file when selecting between multiple valid Java designs.
 
-## Concurrency
-- Avoid shared mutable state; use immutability or confinement.
-- When sharing state, use proper synchronization and document invariants.
+## Semantic Dependencies
+- Inherit all rules from `LANGUAGE/JAVA/JAVA.md`.
+- Inherit cross-cutting and testing rules from `SECURITY/SECURITY.md` and
+  `TEST/TEST.md`.
+- If this file conflicts with baseline Java guidance, baseline safety rules stay
+  authoritative unless this file explicitly narrows behavior.
 
-## Exceptions and Resources
+## Core Design Preferences
+- Prefer static factories over constructors when they improve readability,
+  caching, or subtype flexibility.
+- Use builders for objects with many optional parameters or invariants.
+- Prefer immutable value types and make defensive copies of mutable state.
+- Prefer composition over inheritance unless subtype truly models an `is-a`
+  relationship.
+- Minimize visibility of classes/members; keep APIs as small as possible.
+
+## Equality and Identity
+- Override `equals` and `hashCode` together when value semantics apply.
+- Keep equality consistent with domain meaning; avoid including volatile or
+  derived fields unintentionally.
+- Keep `toString` useful for diagnostics but free of secrets.
+
+## Generics and Collections
+- Prefer generic types over raw types.
+- Favor lists over arrays for API boundaries unless primitive array performance
+  is required.
+- Use bounded wildcards intentionally (`? extends`, `? super`) to improve API
+  flexibility.
+- Prefer empty collections over `null` returns.
+
+## Optional and Nullability
+- Return `Optional<T>` when absence is part of API semantics.
+- Avoid `Optional` in fields/parameters unless there is a specific reason.
+- Do not use `Optional.get()` without presence checks.
+
+## Exceptions and Resource Management
+- Throw domain-relevant exception types with actionable context.
 - Use checked exceptions only for recoverable conditions.
-- Prefer try-with-resources for closeable resources.
+- Use try-with-resources for closeable resources.
+- Never ignore exceptions; if suppressed intentionally, document rationale.
 
-## Performance
-- Avoid premature optimization; measure before tuning.
-- Be mindful of allocation and hot paths in performance-critical code.
+## Concurrency Guidance
+- Prefer immutable/shared-nothing designs over synchronization.
+- Use high-level concurrency abstractions (`ExecutorService`,
+  `CompletableFuture`, structured APIs) over ad-hoc thread creation.
+- Document thread-safety guarantees for shared components.
+- Avoid exposing mutable static state.
+
+## Serialization and Compatibility
+- Prefer explicit DTO/schema mappers over default Java serialization.
+- If Java serialization is unavoidable, declare `serialVersionUID` and treat
+  serialized forms as compatibility contracts.
+- Validate invariants after deserialization.
+
+## High-Risk Pitfalls
+1. Mutable value objects used as map/set keys.
+2. Incorrect `equals`/`hashCode` causing container corruption.
+3. Telescoping constructors with unclear argument ordering.
+4. Raw types and unchecked casts leaking runtime failures.
+5. Inheritance used for reuse instead of true subtype semantics.
+6. Hidden shared mutable state in static utilities.
+7. Java serialization used accidentally as persistence format.
+
+## Do / Don't Examples
+### 1. Static Factory vs Constructor Overload Noise
+```java
+// Don't: ambiguous overloaded constructors.
+new User(true, false, "admin", 3600);
+
+// Do: named static factories/builders for intent clarity.
+User user = User.adminWithSessionTimeout(3600);
+```
+
+### 2. equals/hashCode Contract
+```java
+// Don't: override equals without hashCode.
+@Override
+public boolean equals(Object other) { ... }
+
+// Do: keep both methods aligned.
+@Override
+public boolean equals(Object other) { ... }
+
+@Override
+public int hashCode() { ... }
+```
+
+### 3. Defensive Copy
+```java
+// Don't: expose internal mutable date.
+public Date createdAt() {
+  return createdAt;
+}
+
+// Do: return defensive copy.
+public Date createdAt() {
+  return new Date(createdAt.getTime());
+}
+```
+
+## Code Review Checklist for Effective Java
+- Is object construction API clear (`static factory`/`builder` when needed)?
+- Are immutability and defensive copies applied at boundaries?
+- Are equals/hashCode/toString semantics correct and safe?
+- Are generics used correctly (no raw types/leaky casts)?
+- Are resources closed safely via try-with-resources?
+- Are concurrency/thread-safety guarantees explicit?
+- Are inheritance decisions justified as true subtype modeling?
+- Is serialization strategy explicit and compatibility-safe?
+
+## Testing Guidance
+- Add contract tests for equals/hashCode behavior.
+- Test immutability/defensive-copy invariants.
+- Test builder/factory invariants and invalid parameter handling.
+- Test concurrent access behavior for shared components.
+- Test serialization/deserialization compatibility where relevant.
+
+## Override Notes
+- This file narrows `JAVA.md` with preference heuristics.
+- When heuristics conflict with explicit project constraints (performance,
+  interoperability), document the tradeoff and preserve baseline safety rules.


### PR DESCRIPTION
## Summary
- rewrite `LANGUAGE/JAVA/EFFECTIVE_JAVA.md` into a deep specialization doc
- add explicit dependencies, design preferences, pitfalls, examples, checklist,
  and testing guidance
- keep guidance additive to `LANGUAGE/JAVA/JAVA.md`

## Validation
- `npx --yes markdownlint-cli2 LANGUAGE/JAVA/EFFECTIVE_JAVA.md`

Closes #124
Part of #87
