### PR TITLE
Deepen language conventions baseline

### DIFF
--- a/LANGUAGE/CONVENTIONS.md
+++ b/LANGUAGE/CONVENTIONS.md
@@ -1,35 +1,120 @@
 # CONVENTIONS
 
-## Formatting
-Formatting rules are ordered by precedence:
-1. Standard, language-specific formatting rules.
-2. The ai-rules conventions regarding formatting.
-3. Individual formatting preferences (lowest priority).
+Guidance for AI agents on cross-language naming and formatting conventions.
 
-### Rules
-- Follow standard language-specific formatting rules when they exist.
-- It is not allowed to override standard formatting rules, even by team
-  consensus.
-- If not conflicting with standard formatting rules, apply the ai-rules
-  conventions and keep them consistent across the codebase.
-- For function/method parameter lists and function/method call argument lists
-  with more than 3 items, use multiline formatting in new/changed code.
-- If parameter/argument lists are multiline, place each item on its own line.
-- If parameter/argument lists are multiline, require a trailing delimiter (for
-  example, a trailing comma in comma-separated lists) on the last item when
-  supported by the language.
+## Scope
+- Define repository-wide conventions that apply before language/framework
+  specializations.
+- Apply this file when generating code and during code review across all
+  languages.
 
-## Naming Conventions
+## Semantic Dependencies
+- Inherit global precedence and override rules from
+  `CORE/RULE_DEPENDENCY_TREE.md`.
+- Inherit readability constraints from `LANGUAGE/READABILITY.md`.
+- Language-specific docs may narrow style details but must not silently weaken
+  clarity or consistency constraints.
+
+## Precedence Model
+Formatting and naming decisions must follow this order:
+1. Language/ecosystem standards and official style rules.
+2. Repository conventions in this file.
+3. Project-local conventions that do not conflict with 1 or 2.
+
+Rules:
+- Do not override established language standards with team preference.
+- If multiple style tools exist, choose one canonical formatter/linter path.
+- Resolve ambiguity by favoring consistency with existing code in the module.
+
+## Formatting Baseline
+- Use auto-formatters where available; do not hand-format against tooling.
+- Keep multiline parameter/argument lists when item count is high (typically
+  more than three) or readability improves.
+- In multiline comma-separated lists, keep one item per line.
+- Use trailing delimiters in multiline lists when language/tooling supports it.
+- Keep import/group ordering deterministic.
+- Avoid alignment formatting that is fragile under edits.
+
+## Naming Baseline
 - Use English names by default.
-- Non-English terms are allowed and encouraged when the project domain uses a
-  specific term without a clear English translation or where the original term
-  is more precise.
-- Follow language-standard naming rules (e.g., class names, method names,
-  constants).
-- Abbreviations are forbidden unless they are widely known in general or in the
-  project's domain.
-- Treat an abbreviation as a single word for casing (e.g., `getUrl()` is
-  correct; `getURL()` is incorrect).
-- Prefer clear, descriptive names.
-- Use consistent casing and prefixes within a codebase.
-- Avoid misleading names; names must reflect intent.
+- Domain-native non-English terms are acceptable when they are canonical,
+  precise, and consistently used.
+- Prefer descriptive names over compressed/cryptic names.
+- Names should express intent and role, not implementation mechanics.
+- Keep naming consistent within module boundaries.
+
+## Casing Rules (General)
+Apply language-standard casing as default:
+- Types/class-like constructs: `PascalCase`.
+- Variables/functions/methods: `camelCase`.
+- True constants: language-standard constant style
+  (commonly `UPPER_SNAKE_CASE`, but follow language conventions).
+- File/directory casing should follow ecosystem conventions and existing module
+  pattern.
+
+## Abbreviation Policy
+- Avoid abbreviations unless broadly recognized.
+- If abbreviation is used, treat it as one word for casing (`userId`,
+  `httpClient`, `xmlParser`).
+- Do not mix styles (`getURL` and `getUrl`) in the same codebase.
+- Prefer expanding obscure domain shorthand in public APIs.
+
+## Identifier Quality Rules
+- Boolean names should read as predicates (`isActive`, `hasAccess`).
+- Collections should use plural names.
+- Temporal values should include units (`timeoutMs`, `expiresAt`).
+- Avoid misleading names that imply stronger guarantees than implementation.
+- Avoid generic names (`data`, `result`, `temp`) unless scope is tiny and clear.
+
+## Comment and Documentation Naming
+- Keep comment terminology aligned with code identifiers.
+- Rename related comments/docs when renaming key identifiers.
+- Avoid stale terminology drift between code and documentation.
+
+## High-Risk Pitfalls
+1. Project-specific naming that contradicts language standards.
+2. Inconsistent acronym casing across files/modules.
+3. Generic names that hide domain meaning.
+4. Unit-less numeric names causing interpretation errors.
+5. Formatter drift from manual edits and inconsistent tool usage.
+6. Naming collisions where different concepts share same identifier stem.
+
+## Do / Don't Examples
+### 1. Abbreviation Casing
+```text
+Don't: getURL(), parseXML(), userID
+Do:    getUrl(), parseXml(), userId
+```
+
+### 2. Unit Clarity
+```text
+Don't: retryTimeout = 5
+Do:    retryTimeoutSeconds = 5
+```
+
+### 3. Generic Naming
+```text
+Don't: process(data)
+Do:    processInvoiceBatch(invoiceBatch)
+```
+
+## Code Review Checklist for Conventions
+- Are language-standard formatting and naming rules followed?
+- Are naming decisions descriptive and consistent within module scope?
+- Are abbreviations necessary and consistently cased?
+- Are booleans/predicates named semantically?
+- Are numeric/time fields unit-explicit?
+- Are multiline formatting and trailing delimiter rules applied consistently?
+- Did refactors keep identifier names aligned across code/comments/docs?
+
+## Testing and Validation Guidance
+- Keep formatter/linter checks mandatory in CI.
+- Use naming-convention lint rules where ecosystem support exists.
+- Add static checks for import ordering and formatting drift.
+- Treat style lint failures as quality-gate failures, not optional warnings.
+
+## Override Notes
+- Language docs may define stricter naming rules (for example TypeScript enum
+  member casing).
+- Framework/library docs may define local naming idioms, but must remain
+  compatible with this baseline and language standards.


### PR DESCRIPTION
## Summary
- rewrite `LANGUAGE/CONVENTIONS.md` into a deep cross-language baseline
- add precedence model, formatting/naming rules, pitfalls, examples, and
  review/testing guidance
- clarify abbreviation and casing policies aligned with standards

## Validation
- `npx --yes markdownlint-cli2 LANGUAGE/CONVENTIONS.md`

Closes #126
Part of #87
