### PR TITLE
Deepen Tailwind CSS framework guidance

### DIFF
--- a/FRAMEWORK/TAILWIND_CSS.md
+++ b/FRAMEWORK/TAILWIND_CSS.md
@@ -1,21 +1,91 @@
 # TAILWIND_CSS
 
-Guidance for Tailwind CSS usage.
+Guidance for AI agents implementing and reviewing Tailwind CSS code.
+
+## Scope
+- Define Tailwind-specific rules for scalable, readable, and accessible styling.
+- Apply this file to Tailwind class usage, config, and component extraction.
+
+## Semantic Dependencies
+- Inherit CSS baseline from `LANGUAGE/CSS/CSS.md`.
+- Inherit HTML accessibility baseline from `LANGUAGE/HTML/HTML.md`.
+- Framework docs may add component conventions but should preserve this file's
+  maintainability constraints.
 
 ## Defaults
-- Keep utility classes readable and grouped by purpose (layout, spacing,
-  typography, color).
-- Use design tokens consistently (colors, spacing, typography scales).
-- Prefer component extraction when class lists grow large.
+- Prefer utility-first styling with clear class grouping by concern
+  (layout, spacing, typography, color, state).
+- Keep class lists readable and intentional.
+- Use design tokens via Tailwind theme configuration instead of ad-hoc values.
+- Prefer component extraction when class lists become repetitive or complex.
 
-## Structure
-- Create shared components for repeated UI patterns.
-- Use `@apply` sparingly; prefer composition via components.
+## Utility and Composition Rules
+- Keep utilities local to component intent.
+- Avoid giant one-off class strings with many conditionals.
+- Prefer reusable abstractions for repeated UI patterns.
+- Use `@apply` sparingly and only when it improves maintainability.
+- Keep variant usage (`sm:`, `md:`, `hover:`, `focus:`) predictable and minimal.
 
-## Performance
-- Remove unused classes via purge/content configuration.
-- Avoid large custom utility layers unless necessary.
+## Design System Alignment
+- Centralize colors, spacing, typography scales in config.
+- Avoid arbitrary values unless genuinely required.
+- Keep naming aligned with design language, not implementation details.
+- Review custom plugins/utilities for long-term maintainability.
 
-## Consistency
-- Enforce class ordering via a formatter or lint rule.
-- Keep responsive variants consistent across components.
+## Accessibility and UX
+- Preserve focus-visible states.
+- Ensure color contrast compliance.
+- Ensure disabled/loading/error states are visually and semantically clear.
+- Avoid motion-heavy transitions without reduced-motion consideration.
+
+## Performance Baseline
+- Ensure content paths are configured so unused classes are purged.
+- Avoid dynamically constructed class names that evade static extraction.
+- Keep generated CSS size monitored in CI/release checks.
+- Prefer stable class composition over runtime string-generation complexity.
+
+## High-Risk Pitfalls
+1. Utility sprawl making components unreadable.
+2. Arbitrary value overuse bypassing design system.
+3. Dynamic class name generation breaking purge/content extraction.
+4. Missing focus/contrast accessibility states.
+5. Excessive responsive/state variants causing style bloat.
+6. Duplicated style patterns across components with no abstraction.
+
+## Do / Don't Examples
+### 1. Reuse
+```text
+Don't: copy/paste same 20 utility classes in many files.
+Do:    extract shared component or utility composition.
+```
+
+### 2. Arbitrary Values
+```text
+Don't: w-[317px] text-[#4a6dff] everywhere.
+Do:    use theme tokens and approved spacing/size scales.
+```
+
+### 3. Dynamic Classes
+```text
+Don't: className={`text-${color}-600`}
+Do:    map known variants to explicit class strings.
+```
+
+## Code Review Checklist for Tailwind
+- Are class lists readable and grouped by concern?
+- Are design tokens used instead of arbitrary values?
+- Are repeated patterns extracted appropriately?
+- Are dynamic classes purge-safe and explicit?
+- Are accessibility states (focus/contrast/disabled/error) present?
+- Is generated CSS size and variant usage controlled?
+
+## Testing Guidance
+- Add visual regression tests for shared components.
+- Add accessibility checks for color contrast and focus states.
+- Test responsive variants at key breakpoints.
+- Validate production build output to ensure unused class purge works.
+
+## Override Notes
+- Project-specific design system docs may define stricter token/component
+  constraints, but accessibility and maintainability baseline here remains
+  mandatory.


### PR DESCRIPTION
## Summary
- rewrite `FRAMEWORK/TAILWIND_CSS.md` into deep Tailwind guidance
- add utility strategy, token governance, reuse rules, accessibility, and
  build-performance guardrails
- add pitfalls, examples, review checklist, and testing guidance

## Validation
- `npx --yes markdownlint-cli2 FRAMEWORK/TAILWIND_CSS.md`

Closes #160
Part of #87
