### PR TITLE
Deepen Bun build-tool guidance

### DIFF
--- a/BUILD_TOOLS/BUN.md
+++ b/BUILD_TOOLS/BUN.md
@@ -1,31 +1,95 @@
 # BUN
 
-Guidance for Bun as a package manager.
+Guidance for AI agents using Bun as package manager/runtime tooling.
 
-## General
-- Use a single JavaScript package manager per repo; do not mix lockfiles.
-- `bun install` writes a `bun.lock` lockfile; commit it when lockfiles are tracked.
-- Bun does not run dependency lifecycle scripts by default; use `trustedDependencies`
-  for packages that require them.
-- Bun installs dependencies into `node_modules/`; keep it out of version control.
+## Scope
+- Define Bun-specific dependency/install behavior and compatibility controls.
+- Apply this file when Bun is chosen for package management or script runtime.
 
-## Lockfile
-- Generate a lockfile without installing to `node_modules`:
-  `bun install --lockfile-only`
-- Install without creating a lockfile only when explicitly requested:
-  `bun install --no-save`
-- Bun supports a text `bun.lock` and older binary `bun.lockb`; prefer `bun.lock`
-  when available.
+## Semantic Dependencies
+- Inherit baseline Node dependency controls from `BUILD_TOOLS/NPM.md`.
+- Inherit security/compliance constraints from
+  `SECURITY/SECURITY.md` and `COMPLIANCE/LICENSES.md`.
+- This file specializes Bun-specific behavior and caveats.
 
-## bunfig.toml
-- `bunfig.toml` is optional and only needed for Bun-specific settings.
-- Add it to the project root when you need project-local configuration.
-- Bun also supports `.npmrc`, but migrating to `bunfig.toml` is recommended.
+## Defaults
+- Use one package manager per repository; do not mix lockfiles.
+- Commit Bun lockfile for reproducible installs.
+- Keep Bun version pinned in project/tooling config.
+- Validate Bun compatibility with required ecosystem tooling before adoption.
+
+## Install and Lockfile Behavior
+- Use deterministic install behavior in CI.
+- Prefer `bun install --frozen-lockfile` (or equivalent reproducible mode) for
+  release pipelines.
+- Use `bun install --lockfile-only` only when intentionally updating lock
+  metadata.
+- Keep node_modules excluded from VCS.
+
+## Lifecycle Script and Trust Model
+- Bun dependency lifecycle script behavior differs from npm ecosystem defaults.
+- Explicitly configure trusted dependencies when lifecycle scripts are required.
+- Do not blanket-trust all dependency scripts.
+- Validate build/install outcome for packages requiring postinstall steps.
+
+## Compatibility Guardrails
+- Verify package manager features needed by monorepo/workspace setup.
+- Validate CI images/runners include expected Bun version.
+- Keep fallback path documented if Bun compatibility blocks delivery.
+- Avoid mixing Bun runtime assumptions into scripts intended for Node-only
+  environments without explicit checks.
+
+## Security and Credential Handling
+- Never commit registry credentials/tokens.
+- Use CI secret injection for registry auth.
+- Scan dependencies and lockfile for vulnerabilities.
+- Keep trusted dependency policy minimal and auditable.
 
 ## VCS Ignore Additions
-Add these when using Bun (if not already covered by the baseline ignore list):
+Add these when using Bun (if not already covered by baseline ignore rules):
 - `node_modules/`
 
-## .npmrc Handling
-- Do not commit `.npmrc` if it contains credentials or auth tokens; add it to `.gitignore`.
-- If `.npmrc` is required, commit a sanitized version and consider `.npmrc.example`.
+## High-Risk Pitfalls
+1. Mixing Bun lockfile with npm/pnpm/yarn lockfiles.
+2. Assuming npm lifecycle script behavior without validation.
+3. Unpinned Bun version leading to CI/local drift.
+4. Trusting dependency scripts broadly.
+5. Runtime/script incompatibilities hidden until deployment.
+6. Registry credentials committed in config files.
+
+## Do / Don't Examples
+### 1. Lockfile Discipline
+```text
+Don't: keep both bun.lock and package-lock.json.
+Do:    keep Bun lockfile only when Bun is selected.
+```
+
+### 2. Script Trust
+```text
+Don't: trust all postinstall scripts globally.
+Do:    explicitly allow trusted dependencies only.
+```
+
+### 3. CI Reproducibility
+```text
+Don't: run floating bun install mode in release CI.
+Do:    use frozen lockfile mode with pinned Bun version.
+```
+
+## Code Review Checklist for Bun
+- Is Bun selected intentionally and consistently?
+- Is lockfile policy deterministic and enforced in CI?
+- Are lifecycle script trust decisions explicit and minimal?
+- Are compatibility constraints tested for required tooling/workspaces?
+- Are credentials/tokens excluded from committed config?
+- Are dependency security checks integrated?
+
+## Testing Guidance
+- Test clean install on CI runner and local dev baseline.
+- Test package install behavior for deps requiring scripts.
+- Run full build/test workflow under Bun in CI.
+- Add regression checks when upgrading Bun major/minor versions.
+
+## Override Notes
+- If project must interoperate with npm-specific workflows, document explicit
+  compatibility boundaries and keep deterministic lockfile/security controls.


### PR DESCRIPTION
## Summary
- rewrite `BUILD_TOOLS/BUN.md` into deep Bun guidance
- add Bun-specific lockfile/install/trusted-dependency and compatibility rules
- add pitfalls, examples, review checklist, and testing guidance

## Validation
- `npx --yes markdownlint-cli2 BUILD_TOOLS/BUN.md`

Closes #166
Part of #87
