### PR TITLE
Deepen SOLID design guidance

### DIFF
--- a/DESIGN/SOLID.md
+++ b/DESIGN/SOLID.md
@@ -1,23 +1,86 @@
 # SOLID
 
-Concise, practical guidance for the SOLID principles.
+Guidance for AI agents applying SOLID principles pragmatically.
 
-## Single Responsibility Principle (SRP)
-- A module should have one reason to change.
-- Keep responsibilities narrow and cohesive.
+## Scope
+- Define practical SOLID usage for maintainable, extensible software design.
+- Apply this file during design and review, not as rigid dogma.
 
-## Open/Closed Principle (OCP)
-- Extend behavior through new code, not by modifying existing behavior.
-- Favor abstractions and composition when change is expected.
+## Semantic Dependencies
+- Inherit clean-code baseline from `DESIGN/CLEAN_CODE.md`.
+- Inherit architecture boundary rules from `ARCHITECTURE/CLEAN_ARCHITECTURE.md`.
 
-## Liskov Substitution Principle (LSP)
-- Subtypes must be usable in place of supertypes without breaking correctness.
-- Avoid strengthening preconditions or weakening postconditions in overrides.
+## SRP: Single Responsibility Principle
+- Keep modules with one primary reason to change.
+- Separate orchestration, policy, and IO responsibilities.
+- Avoid classes that mix domain logic, persistence, and transport concerns.
 
-## Interface Segregation Principle (ISP)
-- Prefer small, specific interfaces over large, general ones.
-- Do not force clients to depend on methods they do not use.
+## OCP: Open/Closed Principle
+- Design extension seams where change vectors are expected.
+- Prefer composition/polymorphism over branching explosion for variants.
+- Avoid speculative abstractions without credible extension need.
 
-## Dependency Inversion Principle (DIP)
-- Depend on abstractions, not concretions.
-- Keep high-level policy independent of low-level details.
+## LSP: Liskov Substitution Principle
+- Subtypes must honor base type contracts.
+- Do not strengthen preconditions or weaken postconditions.
+- Keep behavioral compatibility explicit in inheritance hierarchies.
+
+## ISP: Interface Segregation Principle
+- Prefer narrow interfaces focused on client needs.
+- Avoid large kitchen-sink interfaces.
+- Keep interface methods cohesive and role-specific.
+
+## DIP: Dependency Inversion Principle
+- Depend on abstractions across boundary seams.
+- Keep high-level policy independent from low-level framework details.
+- Compose implementations at outer boundaries.
+
+## Tradeoff Guidance
+- SOLID is a decision aid, not a hard quota.
+- Prefer simple direct code when extension pressure is low.
+- Introduce abstraction when it reduces expected change cost.
+- Document deliberate deviations when pragmatic constraints apply.
+
+## High-Risk Pitfalls
+1. Over-abstraction from dogmatic SOLID application.
+2. Huge interface hierarchies with little value.
+3. Inheritance hierarchies violating substitutability.
+4. Dependency inversion applied superficially while leaking concrete types.
+5. SRP ignored in service/controller "god objects".
+
+## Do / Don't Examples
+### 1. SRP
+```text
+Don't: one class validates input, persists data, and sends notifications.
+Do:    separate responsibilities into focused collaborators.
+```
+
+### 2. OCP
+```text
+Don't: giant if/else for every new payment type.
+Do:    strategy interface with pluggable implementations.
+```
+
+### 3. ISP
+```text
+Don't: Repository interface with unrelated read/write/admin methods.
+Do:    split read and write interfaces by client need.
+```
+
+## Code Review Checklist for SOLID
+- Does each module have a clear reason to change?
+- Are extension points aligned with actual change vectors?
+- Are subtype contracts behaviorally compatible?
+- Are interfaces client-focused and minimal?
+- Are high-level modules isolated from low-level details?
+- Is abstraction level proportional to complexity?
+
+## Testing Guidance
+- Add contract tests for polymorphic interfaces/subtypes.
+- Add focused unit tests for strategy implementations.
+- Add architecture tests to enforce dependency direction.
+- Add regression tests when refactoring responsibilities/interfaces.
+
+## Override Notes
+- Framework constraints may require pragmatic compromises, but contract
+  compatibility and boundary isolation principles remain mandatory.


### PR DESCRIPTION
## Summary
- rewrite `DESIGN/SOLID.md` into deep practical SOLID guidance
- add principle-specific rules, tradeoff guidance, and anti-pattern controls
- add pitfalls, examples, review checklist, and testing guidance

## Validation
- `npx --yes markdownlint-cli2 DESIGN/SOLID.md`

Closes #210
Part of #87
