### PR TITLE
Deepen planning overlay guidance

### DIFF
--- a/PLAN/PLAN.md
+++ b/PLAN/PLAN.md
@@ -1,24 +1,88 @@
 # PLAN
 
-Guidance for creating execution plans.
+Guidance for AI agents creating implementation plans.
 
-## When to Plan
-- Use a plan for multi-step, risky, or high-impact work.
-- Skip detailed planning for trivial changes; proceed directly.
+## Scope
+- Define planning standards for multi-step or high-risk tasks.
+- Apply this file when producing execution plans before implementation.
 
-## Plan Contents
-- Goal and success criteria (what "done" means).
-- Scope boundaries and non-goals.
-- Assumptions and open questions.
-- Dependencies, risks, and rollback considerations.
-- Verification strategy and test plan.
+## Semantic Dependencies
+- Inherit dependency order from `CORE/RULE_DEPENDENCY_TREE.md`.
+- Inherit testing/security/compliance constraints from
+  `TEST/TEST.md`, `SECURITY/SECURITY.md`, and `COMPLIANCE/COMPLIANCE.md`.
+- Inherit workflow constraints from `CORE/VERSION_CONTROL_SYSTEM.md`.
 
-## Test Planning Requirements
-- Add missing tests before modifying behavior when current behavior is unclear.
-- Add tests for new code or changed behavior.
-- Run the tests and verify they succeed; state if tests were not run.
+## When Planning Is Required
+- Multi-document or multi-repo changes.
+- High-risk refactors and behavior changes.
+- Work spanning multiple semantic layers (language/framework/library/infra).
+- Any change with unclear requirements or significant rollback risk.
 
-## Plan Format
-- Use short, ordered steps with clear outcomes.
-- Keep steps small enough to validate independently.
-- Update the plan if scope or assumptions change.
+## Decision-Complete Plan Requirements
+A plan must specify:
+- Goal and success criteria.
+- In-scope and out-of-scope items.
+- Semantic dependency order and target files.
+- Key design decisions with rationale and chosen defaults.
+- Edge cases/failure modes and mitigation strategy.
+- Verification strategy (tests/checks) and acceptance criteria.
+- Rollout/rollback or migration steps where relevant.
+
+## Plan Quality Rules
+- Keep steps concrete and implementable.
+- Avoid ambiguous TODO-style phrasing.
+- Keep assumptions explicit; avoid hidden decisions.
+- Mark where follow-up issues are needed.
+- Keep plan aligned with one-issue/one-branch/one-PR workflow when required.
+
+## Risk and Dependency Handling
+- Identify external dependencies and blockers early.
+- Call out coupling across layers and documents.
+- Prefer dependency-first ordering (parent constraints before child
+  specialization).
+- Include rollback options for high-impact changes.
+
+## Testing and Validation Planning
+- Define required tests before implementation starts.
+- Include regression strategy for changed behavior.
+- Specify mandatory CI checks and quality gates.
+- Define observable acceptance signals for rollout.
+
+## High-Risk Pitfalls
+1. Plans that leave critical decisions to implementation time.
+2. Ignoring semantic dependency order.
+3. Missing verification criteria or measurable "done" definition.
+4. Oversized steps with hidden complexity.
+5. No rollback strategy for risky changes.
+6. Untracked assumptions that later break execution.
+
+## Do / Don't Examples
+### 1. Step Quality
+```text
+Don't: "Update docs and fix related stuff"
+Do:    "Rewrite LANGUAGE/JAVA/JAVA.md with sections A/B/C; add tests X/Y"
+```
+
+### 2. Verification Clarity
+```text
+Don't: "Run tests"
+Do:    "Run markdownlint for touched docs and report pass/fail output"
+```
+
+### 3. Dependency Order
+```text
+Don't: update framework child docs before parent language constraints.
+Do:    update parent baselines first, then child specializations.
+```
+
+## Plan Review Checklist
+- Is the plan decision-complete and implementation-ready?
+- Are scope and success criteria explicit?
+- Are semantic dependencies and ordering correct?
+- Are risks, mitigations, and rollback steps captured?
+- Are testing and acceptance criteria concrete?
+- Are assumptions and follow-ups explicit?
+
+## Override Notes
+- Task-specific user constraints may change execution order, but plans must stay
+  decision-complete and dependency-aware.


### PR DESCRIPTION
## Summary
- rewrite `PLAN/PLAN.md` into deep planning overlay guidance
- add decision-complete planning requirements, risk/dependency handling,
  and verification planning rules
- add pitfalls, examples, and plan review checklist

## Validation
- `npx --yes markdownlint-cli2 PLAN/PLAN.md`

Closes #218
Part of #87
