### PR TITLE
Fix linkcheck UTF-8 parsing failure in GoF design doc

### DIFF
--- a/DESIGN/GOF_DESIGN_PATTERNS.md
+++ b/DESIGN/GOF_DESIGN_PATTERNS.md
@@ -48,7 +48,7 @@ Guidance for AI agents applying GoF patterns pragmatically.
 ## Anti-Pattern Guardrails
 - Avoid speculative pattern layering without real variability pressure.
 - Avoid pattern names as substitutes for clear domain names.
-- Avoid hidden complexity behind façade/proxy without observability.
+- Avoid hidden complexity behind faÃ§ade/proxy without observability.
 - Avoid singleton-as-global-variable design.
 
 ## High-Risk Pitfalls


### PR DESCRIPTION
## Summary
- fix non-UTF8 byte sequence in `DESIGN/GOF_DESIGN_PATTERNS.md`
- replace non-UTF8 `fa�ade` byte sequence with UTF-8-safe text (`facade`)
- unblock `Docs Check` linkcheck (lychee) parsing on markdown corpus

## Validation
- verified all `*.md` files decode as UTF-8 locally

