### PR TITLE
Backfill Copilot review fixes (Wave 3: PR #183-#224)

### DIFF
--- a/COMPLIANCE/LICENSES.md
+++ b/COMPLIANCE/LICENSES.md
@@ -13,8 +13,8 @@ Consult legal counsel for final legal decisions.
 
 ## Semantic Dependencies
 - Inherit compliance baseline from `COMPLIANCE/COMPLIANCE.md`.
-- Inherit dependency-selection constraints from `FRAMEWORK/**`, `LIBRARY/**`,
-  and `BUILD_TOOLS/**`.
+- This file is part of the cross-cutting baseline; downstream framework/library/
+  build-tool docs must comply with this policy.
 
 ## Decision Framework
 For each dependency (direct and significant transitive):
@@ -38,20 +38,23 @@ Typically acceptable for commercial closed-source use:
 ## Conditional Licenses (Review Required)
 Potentially acceptable with constraints and legal review:
 - MPL-2.0
-- LGPL-2.1 / LGPL-3.0
+- LGPL-2.1-only / LGPL-2.1-or-later
+- LGPL-3.0-only / LGPL-3.0-or-later
 - EPL-2.0
 - CDDL-1.0
 
 ## Generally Not Compatible for Closed-Source Distribution
 Avoid unless legal explicitly approves alternative model:
-- GPL-2.0 / GPL-3.0
-- AGPL-3.0
+- GPL-2.0-only / GPL-2.0-or-later
+- GPL-3.0-only / GPL-3.0-or-later
+- AGPL-3.0-only / AGPL-3.0-or-later
 - SSPL-1.0
 - Commons Clause / non-commercial-restricted licenses
 
 ## Attribution and Notice Workflow
 - Preserve required copyright/license notices.
-- Maintain `THIRD_PARTY_NOTICES.md` (or equivalent) for distributed artifacts.
+- For distributed artifacts, maintain `THIRD_PARTY_NOTICES.md` in the project
+  root (or an explicitly documented equivalent path).
 - Include NOTICE file obligations (for example Apache-2.0) in release outputs.
 - Keep attribution metadata updated on dependency upgrades/removals.
 

--- a/DESIGN/CLEAN_CODE.md
+++ b/DESIGN/CLEAN_CODE.md
@@ -5,12 +5,13 @@ review.
 
 ## Scope
 - Define practical code-quality rules for maintainability and clarity.
-- Apply this file across languages/frameworks unless specialized docs narrow a
-  rule explicitly.
+- Apply this file across languages/frameworks as a minimum baseline.
+- Specialized docs may add stricter/idiomatic constraints; explicit overrides
+  must be documented and justified.
 
 ## Semantic Dependencies
-- Inherit readability/naming baselines from `LANGUAGE/CONVENTIONS.md` and
-  `LANGUAGE/READABILITY.md`.
+- Inherit naming baseline from `LANGUAGE/CONVENTIONS.md`.
+- `LANGUAGE/READABILITY.md` is a companion guideline, not a semantic parent.
 - Inherit design constraints from `DESIGN/SOLID.md`.
 
 ## Core Principles
@@ -66,7 +67,7 @@ Do:    separate orchestration from focused operations.
 
 ### 2. Error Context
 ```text
-Don't: throw generic RuntimeException("failed").
+Don't: throw a generic error with no context ("failed").
 Do:    throw domain-specific error with contextual identifiers.
 ```
 

--- a/DESIGN/GOF_DESIGN_PATTERNS.md
+++ b/DESIGN/GOF_DESIGN_PATTERNS.md
@@ -1,4 +1,4 @@
-# GOF_DESIGN_PATTERNS
+﻿# GOF_DESIGN_PATTERNS
 
 Guidance for AI agents applying GoF patterns pragmatically.
 
@@ -29,7 +29,7 @@ Guidance for AI agents applying GoF patterns pragmatically.
 - Adapter:
   isolate incompatible interfaces.
 - Facade:
-  simplify interaction with complex subsystem.
+  simplify interaction with a complex subsystem.
 - Decorator:
   extend behavior without subclass explosion.
 - Proxy:
@@ -48,7 +48,7 @@ Guidance for AI agents applying GoF patterns pragmatically.
 ## Anti-Pattern Guardrails
 - Avoid speculative pattern layering without real variability pressure.
 - Avoid pattern names as substitutes for clear domain names.
-- Avoid hidden complexity behind façade/proxy without observability.
+- Avoid hidden complexity behind facade/proxy without observability.
 - Avoid singleton-as-global-variable design.
 
 ## High-Risk Pitfalls

--- a/DESIGN/SOLID.md
+++ b/DESIGN/SOLID.md
@@ -7,8 +7,10 @@ Guidance for AI agents applying SOLID principles pragmatically.
 - Apply this file during design and review, not as rigid dogma.
 
 ## Semantic Dependencies
-- Inherit clean-code baseline from `DESIGN/CLEAN_CODE.md`.
-- Inherit architecture boundary rules from `ARCHITECTURE/CLEAN_ARCHITECTURE.md`.
+- Inherit cross-cutting precedence/override model from
+  `CORE/RULE_DEPENDENCY_TREE.md`.
+- `DESIGN/CLEAN_CODE.md` and `ARCHITECTURE/CLEAN_ARCHITECTURE.md` are related
+  companion docs that apply alongside this file.
 
 ## SRP: Single Responsibility Principle
 - Keep modules with one primary reason to change.

--- a/LIBRARY/JOOQ.md
+++ b/LIBRARY/JOOQ.md
@@ -9,7 +9,10 @@ Guidance for AI agents implementing and reviewing jOOQ-based data access.
 ## Semantic Dependencies
 - Inherit SQL baseline from `LANGUAGE/SQL/SQL.md`.
 - Inherit Java baseline from `LANGUAGE/JAVA/JAVA.md`.
-- Inherit N+1 and transaction safety constraints from architecture docs.
+- Inherit N+1 constraints from `ARCHITECTURE/N_PLUS_1.md`.
+- Inherit transaction/boundary constraints from
+  `ARCHITECTURE/ARCHITECTURE.md` and `FRAMEWORK/SPRING_BOOT.md` where
+  applicable.
 
 ## Defaults
 - Prefer generated jOOQ types for compile-time safety.

--- a/LIBRARY/JPA.md
+++ b/LIBRARY/JPA.md
@@ -10,8 +10,9 @@ Guidance for AI agents implementing and reviewing JPA-based persistence.
 - Inherit Java baseline from `LANGUAGE/JAVA/JAVA.md`.
 - Inherit SQL and N+1 constraints from
   `LANGUAGE/SQL/SQL.md` and `ARCHITECTURE/N_PLUS_1.md`.
-- Inherit Spring/repository boundary constraints from framework docs where
-  relevant.
+- Inherit framework boundary constraints from `FRAMEWORK/SPRING_BOOT.md`.
+- Cross-cutting baselines are inherited transitively via the language/framework
+  parents above.
 
 ## Defaults
 - Keep entities persistence-focused; keep business workflows in services.

--- a/LIBRARY/JUNIT.md
+++ b/LIBRARY/JUNIT.md
@@ -8,8 +8,11 @@ Guidance for AI agents implementing and reviewing JUnit tests.
 
 ## Semantic Dependencies
 - Inherit global testing baseline from `TEST/TEST.md`.
-- Inherit language readability/conventions from `LANGUAGE/**` docs.
-- Mockito/other test-library docs may specialize mocking/integration behavior.
+- Inherit language/readability baselines from
+  `LANGUAGE/JAVA/JAVA.md`, `LANGUAGE/CONVENTIONS.md`, and
+  `LANGUAGE/READABILITY.md`.
+- `LIBRARY/MOCKITO.md` and other test-library docs may specialize
+  mocking/integration behavior.
 
 ## Defaults
 - Use JUnit 5.

--- a/LIBRARY/KAFKA.md
+++ b/LIBRARY/KAFKA.md
@@ -27,7 +27,10 @@ Guidance for AI agents implementing and reviewing Apache Kafka usage.
 
 ## Producer Rules
 - Keep key strategy intentional for partition affinity/order semantics.
-- Enable idempotent producer where duplicate prevention matters.
+- Enable idempotent producer settings (`enable.idempotence` with compatible
+  `acks`/retry configuration) where retry-duplicate suppression is required.
+- Treat producer idempotence as a producer-session guarantee only; handle
+  end-to-end deduplication/idempotency at consumer/workflow boundaries.
 - Handle send failures with clear retry/error policy.
 - Avoid fire-and-forget publishing without observability.
 

--- a/LIBRARY/LOMBOK.md
+++ b/LIBRARY/LOMBOK.md
@@ -21,7 +21,7 @@ Guidance for AI agents implementing and reviewing Lombok usage.
 
 ## Annotation Selection Policy
 - `@Getter`/`@Setter`: use selectively based on encapsulation intent.
-- `@Value`: prefer for immutable DTO/value objects.
+- `@Value` (`lombok.Value`): prefer for immutable DTO/value objects.
 - `@Data`: avoid by default on domain entities and types with nuanced identity.
 - `@EqualsAndHashCode`: configure intentionally for inheritance/identity.
 - `@ToString`: avoid exposing large graphs or sensitive fields.

--- a/LIBRARY/MOCKITO.md
+++ b/LIBRARY/MOCKITO.md
@@ -26,7 +26,9 @@ Guidance for AI agents implementing and reviewing Mockito-based tests.
 
 ## Verification Rules
 - Verify meaningful interactions, not every call by default.
-- Use strict verification for critical side effects.
+- Use explicit/precise verification for critical side effects
+  (for example once/never checks and argument constraints).
+- Prefer strict stubbing to catch unused or mismatched stubs.
 - Avoid over-verifying call counts in non-critical paths.
 - Prefer `verifyNoMoreInteractions` sparingly and intentionally.
 

--- a/LIBRARY/PLAYWRIGHT.md
+++ b/LIBRARY/PLAYWRIGHT.md
@@ -15,7 +15,8 @@ Guidance for AI agents implementing and reviewing Playwright tests.
 ## Defaults
 - Focus E2E tests on critical user journeys.
 - Keep tests deterministic with isolated test data/state.
-- Use robust locators (`getByRole`, test IDs) over brittle CSS/xpath chains.
+- Use robust locators (`getByRole`, test IDs via `data-testid` +
+  `getByTestId`) over brittle CSS/XPath chains.
 - Use Playwright auto-waiting and explicit assertions.
 - Keep setup/teardown reusable through fixtures.
 

--- a/PLAN/PLAN.md
+++ b/PLAN/PLAN.md
@@ -15,7 +15,8 @@ Guidance for AI agents creating implementation plans.
 ## When Planning Is Required
 - Multi-document or multi-repo changes.
 - High-risk refactors and behavior changes.
-- Work spanning multiple semantic layers (language/framework/library/infra).
+- Work spanning multiple semantic layers
+  (language/framework/library/infrastructure/CI-CD).
 - Any change with unclear requirements or significant rollback risk.
 
 ## Decision-Complete Plan Requirements

--- a/PROGRAMMING/PROGRAMMING.md
+++ b/PROGRAMMING/PROGRAMMING.md
@@ -11,11 +11,14 @@ Guidance for AI agents executing implementation tasks.
 - Inherit testing constraints from `TEST/TEST.md`.
 - Inherit security/compliance constraints from `SECURITY/SECURITY.md` and
   `COMPLIANCE/COMPLIANCE.md`.
+- Inherit the full cross-cutting baseline per `CORE/RULE_DEPENDENCY_TREE.md`.
 - Inherit language/framework/tool specifics from relevant leaf docs.
 
 ## Default Execution Workflow
 1. Confirm behavior goals, acceptance criteria, and scope boundaries.
-2. Locate semantic parent docs for language/framework/library used.
+2. Locate semantic parent docs using `CORE/RULE_DEPENDENCY_TREE.md` and the
+   relevant index docs (`LANGUAGE/LANGUAGE.md`, `FRAMEWORK/FRAMEWORK.md`,
+   `LIBRARY/LIBRARY.md`, `BUILD_TOOLS/BUILD_TOOLS.md`).
 3. Design minimal-change implementation path.
 4. Implement with explicit error handling and observability where relevant.
 5. Add/update tests and run verification.
@@ -87,5 +90,6 @@ Do:    justify necessity, review license/security, and document impact.
 - Include performance-sensitive checks where applicable.
 
 ## Override Notes
-- Task-specific overlays (`PLAN`, `REVIEW`) may adjust output format, but
-  implementation safety/verification requirements here remain mandatory.
+- Task-specific overlays (`PLAN/PLAN.md`, `REVIEW/CODE_REVIEW.md`) may adjust
+  output format, but implementation safety/verification requirements here
+  remain mandatory.

--- a/REVIEW/CODE_REVIEW.md
+++ b/REVIEW/CODE_REVIEW.md
@@ -10,8 +10,9 @@ Guidance for AI agents performing code and rules-document reviews.
 - Inherit review-layer boundary from `REVIEW/REVIEW.md`.
 - Inherit all applicable technical constraints from relevant language/framework/
   library/build/infra docs.
-- Inherit security/testing/compliance severity from
+- Inherit security/testing/compliance constraints and priority direction from
   `SECURITY/SECURITY.md`, `TEST/TEST.md`, `COMPLIANCE/COMPLIANCE.md`.
+- Severity levels are defined by this document's local severity model.
 
 ## Review Priority Order
 1. Correctness and regression risk.


### PR DESCRIPTION
## Summary\nBackfill valid Copilot review findings from merged PRs #183..#224.\n\n## Includes\n- Library semantic-dependency and terminology precision fixes (JPA, jOOQ, JUnit, Mockito, Kafka, Lombok, Playwright)\n- Design dependency-cycle and wording fixes (Clean Code, SOLID, GoF)\n- Overlay clarity updates (PROGRAMMING, PLAN, CODE_REVIEW)\n- Compliance direction/SPDX/notice-path clarifications\n\n## Validation\n- markdownlint: pass\n- linkcheck: validated by CI workflow\n\nRefs #225