### PR TITLE
Follow up unresolved Copilot threads from #228 and #229

### DIFF
--- a/BUILD_TOOLS/BUN.md
+++ b/BUILD_TOOLS/BUN.md
@@ -63,7 +63,8 @@ Add these when using Bun (if not already covered by baseline ignore rules):
 ### 1. Lockfile Discipline
 ```text
 Don't: keep Bun and npm lockfiles together in one repository.
-Do:    keep only the Bun lockfile selected by project Bun version.
+Do:    keep only the Bun lockfile appropriate for the project's pinned Bun
+       version.
 ```
 
 ### 2. Script Trust

--- a/DESIGN/GOF_DESIGN_PATTERNS.md
+++ b/DESIGN/GOF_DESIGN_PATTERNS.md
@@ -1,4 +1,4 @@
-﻿# GOF_DESIGN_PATTERNS
+# GOF_DESIGN_PATTERNS
 
 Guidance for AI agents applying GoF patterns pragmatically.
 

--- a/FRAMEWORK/SVELTE.md
+++ b/FRAMEWORK/SVELTE.md
@@ -32,7 +32,8 @@ Guidance for AI agents implementing and reviewing Svelte projects.
 ## Side Effects and Lifecycle
 - Keep setup/teardown side effects explicit in lifecycle hooks.
 - For dependency-driven side effects, use controlled reactive blocks
-  (`$:` / `$effect`) and avoid uncontrolled reactive side-effect chains.
+  (`$:` in Svelte 3/4, or `$effect` when using Svelte 5+ runes) and avoid
+  uncontrolled reactive side-effect chains.
 - Clean up subscriptions/listeners/timers in teardown paths.
 - Avoid running heavy side effects during rendering paths.
 - Guard browser-only APIs when SSR/hydration is relevant.


### PR DESCRIPTION
## Summary
- gate Svelte reactive side-effect guidance by Svelte version ($: for 3/4, $effect for 5+ runes)
- clarify Bun lockfile wording for project pinned Bun version
- remove UTF-8 BOM from DESIGN/GOF_DESIGN_PATTERNS.md

## Context
This PR addresses unresolved Copilot review comments left on merged Wave PRs #228 and #229.

## Validation
- verified BOM removal at file byte level
- reviewed diffs for wording/version correctness
