### PR TITLE
docs: add lesson learned for escaped issue newlines

### DIFF
--- a/AI-RULES/LESSONS_LEARNED/2026-02-13-github-issue-newline-escaping.md
+++ b/AI-RULES/LESSONS_LEARNED/2026-02-13-github-issue-newline-escaping.md
@@ -1,0 +1,20 @@
+# 2026-02-13-github-issue-newline-escaping
+
+## Scope
+- Applies only to this repository.
+- Do not copy these rules into downstream-projects.
+
+## Issue
+Some GitHub issue bodies were posted with literal `\n` sequences, so GitHub
+rendered them as a single scrambled paragraph instead of formatted Markdown.
+The root cause was submitting an escaped string payload instead of raw Markdown
+with real newline characters.
+
+## Prevention
+- Prefer `gh issue create --body-file <path>` with a raw UTF-8 Markdown file.
+- If content comes from JSON, decode once before posting (for example, with
+  `jq -r`).
+- Add a preflight check that blocks publish when the body contains literal
+  `\n` markers.
+- After creating an issue, verify rendered formatting in GitHub for headings
+  and bullet lists.

--- a/AI-RULES/LESSONS_LEARNED/LESSONS_LEARNED.md
+++ b/AI-RULES/LESSONS_LEARNED/LESSONS_LEARNED.md
@@ -26,6 +26,8 @@ Concrete steps or checks that would have avoided the issue.
 ```
 
 ## Files
+- [2026-02-13-github-issue-newline-escaping.md](2026-02-13-github-issue-newline-escaping.md)
+  - Prevent literal `\n` escape sequences in posted GitHub issue bodies.
 - [2026-02-08-react-example-robustness.md](2026-02-08-react-example-robustness.md)
   - Keep React guidance examples copy/paste compilable and cross-environment robust.
 - [2026-02-07-pr-issue-linking.md](2026-02-07-pr-issue-linking.md)


### PR DESCRIPTION
## Summary
- add a new lesson learned for scrambled GitHub issue bodies caused by literal \\n escapes
- index the new lesson in the lessons overview

## Why
Some issue bodies were posted with escaped newline markers, which rendered as a single scrambled paragraph. This documents prevention and verification steps.

## Testing
- docs-only change
- manually verified issue bodies #43 and #225 are now formatted