### PR TITLE
docs: add downstream override authoring guidance

### DIFF
--- a/AI-RULES/AI-RULES.md
+++ b/AI-RULES/AI-RULES.md
@@ -14,6 +14,8 @@ Guidance for maintaining this ai-rules repository.
 - [RELEASE.md](RELEASE.md) - Release checklist for this repository.
 - [PR-REVIEW-LOOP.md](PR-REVIEW-LOOP.md) - Standard Copilot review loop for
   repository PRs.
+- [DOWNSTREAM-OVERRIDES.md](DOWNSTREAM-OVERRIDES.md) - Authoring model for
+  downstream-project override/extension rules.
 - [UPDATE.md](UPDATE.md) - Update workflow and prompt examples for downstream-projects.
 - [DOWNSTREAM-PROJECT.md](DOWNSTREAM-PROJECT.md) - downstream-project layout and lessons learned guidance.
 - [LESSONS_LEARNED/LESSONS_LEARNED.md](LESSONS_LEARNED/LESSONS_LEARNED.md) - Index of lessons

--- a/AI-RULES/DOWNSTREAM-OVERRIDES.md
+++ b/AI-RULES/DOWNSTREAM-OVERRIDES.md
@@ -1,0 +1,63 @@
+# DOWNSTREAM-OVERRIDES
+
+Meta guidance for maintainers defining how downstream-project overrides should
+be authored by AI agents.
+
+## Scope
+- Applies only to this repository.
+- Do not copy these rules verbatim into downstream-projects.
+
+## Path Model
+- Use placeholders in guidance and templates:
+  - `<AI_ROOT_PATH>`
+  - `<AI_RULES_PATH>`
+  - `<AI_PROJECT_PATH>`
+- Default mapping:
+  - `<AI_ROOT_PATH>=docs/ai`
+  - `<AI_RULES_PATH>=<AI_ROOT_PATH>/AI-RULES`
+  - `<AI_PROJECT_PATH>=<AI_ROOT_PATH>/PROJECT`
+- Never hardcode `docs/ai` when placeholders are available.
+
+## Override Semantics
+- Baseline rules under `<AI_RULES_PATH>` remain authoritative defaults.
+- Downstream files under `<AI_PROJECT_PATH>` extend baseline rules.
+- Default conflict behavior: downstream override takes precedence.
+- Exception: if a baseline rule explicitly forbids override, baseline wins.
+- Missing override content always falls back to baseline behavior.
+
+## File Placement Rules
+- Override baseline topics at the same relative path under
+  `<AI_PROJECT_PATH>` where appropriate.
+- Materialize only files and directories that are actually overridden or added.
+- Avoid copying untouched baseline files into `<AI_PROJECT_PATH>`.
+- Downstream-projects may add additional directories/files not present in
+  baseline when they extend project-specific guidance.
+
+## Link and Index Rules
+- Downstream override entry point is `<AI_PROJECT_PATH>/AI.md`.
+- Every Markdown file under `<AI_PROJECT_PATH>` must be transitively reachable
+  from `<AI_PROJECT_PATH>/AI.md`.
+- While building link chains, mirror baseline structure where appropriate.
+- Additional downstream-only files must also be included in the same reachable
+  index chain.
+- Maintain index hygiene consistently:
+  - Keep clear index files for directories with multiple children.
+  - Keep links updated whenever files move or new files are added.
+
+## Authoring Workflow for AI Agents
+1. Resolve placeholders from the target downstream-project configuration.
+2. Decide whether the new rule is:
+   - an override of an existing baseline topic, or
+   - a downstream-specific extension.
+3. Create/update files under `<AI_PROJECT_PATH>` using placement rules above.
+4. Update index and parent-link chains so every touched file is reachable from
+   `<AI_PROJECT_PATH>/AI.md`.
+5. Verify precedence notes are not contradicting non-overridable baseline
+   constraints.
+6. Validate links and structure before finalizing changes.
+
+## Backward Compatibility
+- If legacy `AI_PROJECT.md` is present, treat it as migration input.
+- Prefer converging to `<AI_PROJECT_PATH>/AI.md` as canonical downstream
+  override entry point.
+- Document migration behavior explicitly in setup/update guidance.

--- a/AI-RULES/DOWNSTREAM-PROJECT.md
+++ b/AI-RULES/DOWNSTREAM-PROJECT.md
@@ -12,11 +12,14 @@ Legacy wording "consuming project" means the same thing.
 - For planning, see [PLAN/PLAN.md](../PLAN/PLAN.md).
 - For implementation, see [PROGRAMMING/PROGRAMMING.md](../PROGRAMMING/PROGRAMMING.md).
 - For review, see [REVIEW/REVIEW.md](../REVIEW/REVIEW.md).
+- For downstream override authoring workflow, see
+  [DOWNSTREAM-OVERRIDES.md](DOWNSTREAM-OVERRIDES.md).
 
 ## Recommended Layout
 - Vendor ai-rules under `docs/ai/AI-RULES/`.
 - Baseline entry point: `docs/ai/AI-RULES/AI.md`.
-- Keep project-specific AI files outside `docs/ai/AI-RULES/` (for example `AI_PROJECT.md`).
+- Keep project-specific AI overrides outside `docs/ai/AI-RULES/`
+  (preferred: `docs/ai/PROJECT/AI.md`, legacy: `AI_PROJECT.md`).
 - Store project lessons learned under `docs/ai/LESSONS_LEARNED/` so updates do not overwrite them.
 - Store project ADRs under `docs/ai/DECISIONS/` so architecture decisions stay
   with project-owned AI docs, not the vendored subtree.
@@ -34,6 +37,6 @@ Legacy wording "consuming project" means the same thing.
 
 ## Entry Points
 - `AGENTS.md` should reference the baseline entry point and any local overlay
-  such as `AI_PROJECT.md`.
-- If you use `docs/ai/LESSONS_LEARNED/`, reference it from `AI_PROJECT.md` or other
-  local guidance.
+  such as `docs/ai/PROJECT/AI.md` (or legacy `AI_PROJECT.md`).
+- If you use `docs/ai/LESSONS_LEARNED/`, reference it from
+  `docs/ai/PROJECT/AI.md` (or legacy `AI_PROJECT.md`) or other local guidance.


### PR DESCRIPTION
## Summary
- add a new AI-RULES meta document for downstream override authoring
- define deterministic path/placement/linking model for AI-authored downstream rules
- codify override precedence and non-overridable baseline exception
- add discoverability links from AI-RULES index and downstream guidance

## Scope
Repository meta guidance only.

Part of #241