### PR TITLE
docs: migrate setup template to <AI_PROJECT_PATH>/AI.md

### DIFF
--- a/AGENTS_TEMPLATE.md
+++ b/AGENTS_TEMPLATE.md
@@ -146,7 +146,8 @@ Local-only update note:
    extensions.
 4. Create a project lessons learned area (recommended):
    `<AI_ROOT_PATH>/LESSONS_LEARNED/LESSONS_LEARNED.md`
-   See `AI-RULES/DOWNSTREAM-PROJECT.md` for guidance.
+   See `AI-RULES/DOWNSTREAM-PROJECT.md` and
+   `AI-RULES/DOWNSTREAM-OVERRIDES.md` for guidance.
 5. Create a project ADR area (recommended):
    `<AI_ROOT_PATH>/DECISIONS/DECISIONS.md`
    `<AI_ROOT_PATH>/DECISIONS/ADR-0001-TITLE.md`


### PR DESCRIPTION
## Summary
- standardize setup placeholders with <AI_ROOT_PATH>, <AI_RULES_PATH>, <AI_PROJECT_PATH>
- switch default setup overlay location to <AI_PROJECT_PATH>/AI.md
- align local/git mode semantics for downstream extension location
- update generated AGENTS/CLAUDE/copilot entrypoint references

## Scope
Sub-issue 2 of epic #241.

Closes #247
Part of #241