### PR TITLE
docs: migrate update and mode-switch to <AI_PROJECT_PATH>

### DIFF
--- a/AI-RULES/UPDATE.md
+++ b/AI-RULES/UPDATE.md
@@ -153,7 +153,7 @@ Steps:
      control for this repo. This requires a commit.
    - Remove tracked ai-rules paths but keep files:
       ```
-      git rm -r --cached --ignore-unmatch -- "<AI_RULES_PATH>" "<AI_PROJECT_PATH>" `
+      git rm -r --cached --ignore-unmatch -- "<AI_RULES_PATH>" "<AI_PROJECT_PATH>" \
         "AGENTS.md" "CLAUDE.md" ".github/copilot-instructions.md"
       ```
       This must succeed even when optional entry-point files are absent.


### PR DESCRIPTION
## Summary
- add <AI_PROJECT_PATH> and <AI_ROOT_PATH> handling in update flow
- migrate local/git mode-switch guidance from legacy AI_PROJECT.md to extension directory semantics
- replace local exclude requirements with /<AI_PROJECT_PATH>/
- add explicit cleanup action for stale legacy AI_PROJECT.md references

## Scope
Sub-issue 3 of epic #241.

Closes #245
Part of #241