### PR TITLE
docs: improve lessons learned for issue body formatting

### DIFF
--- a/AI-RULES/LESSONS_LEARNED/2026-02-13-github-issue-newline-escaping.md
+++ b/AI-RULES/LESSONS_LEARNED/2026-02-13-github-issue-newline-escaping.md
@@ -12,9 +12,11 @@ with real newline characters.
 
 ## Prevention
 - Prefer `gh issue create --body-file <path>` with a raw UTF-8 Markdown file.
+- For updates, use `gh issue edit <id> --body-file <path>` instead of passing
+  escaped inline strings.
 - If content comes from JSON, decode once before posting (for example, with
   `jq -r`).
 - Add a preflight check that blocks publish when the body contains literal
   `\n` markers.
-- After creating an issue, verify rendered formatting in GitHub for headings
-  and bullet lists.
+- After creating or editing an issue, verify rendered formatting in GitHub for
+  headings and bullet lists.

--- a/AI-RULES/LESSONS_LEARNED/LESSONS_LEARNED.md
+++ b/AI-RULES/LESSONS_LEARNED/LESSONS_LEARNED.md
@@ -27,7 +27,7 @@ Concrete steps or checks that would have avoided the issue.
 
 ## Files
 - [2026-02-13-github-issue-newline-escaping.md](2026-02-13-github-issue-newline-escaping.md)
-  - Prevent literal `\n` escape sequences in posted GitHub issue bodies.
+  - Prevent scrambled issue bodies by using `--body-file` for create/edit.
 - [2026-02-08-react-example-robustness.md](2026-02-08-react-example-robustness.md)
   - Keep React guidance examples copy/paste compilable and cross-environment robust.
 - [2026-02-07-pr-issue-linking.md](2026-02-07-pr-issue-linking.md)


### PR DESCRIPTION
Closes #257

## Summary
- strengthen lesson learned for scrambled GitHub issue bodies
- require `--body-file` for both `gh issue create` and `gh issue edit`
- clarify post-create/post-edit render verification step
- align lessons index summary with the updated guidance

## Notes
- Issue #241 body was also corrected directly using `gh issue edit --body-file`.
