### PR TITLE
docs: add copilot instructions for this repository

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,7 @@
+# Copilot Instructions
+
+Use the repository baseline AI rules at:
+- `AI.md`
+
+For repository-maintenance specifics, follow:
+- `AI-RULES/AI-RULES.md`


### PR DESCRIPTION
Closes #235

## Summary
- add `.github/copilot-instructions.md` for this repository
- point Copilot to the canonical entry point `AI.md`
- reference `AI-RULES/AI-RULES.md` for repository-maintenance specifics
