### PR TITLE
docs: add no-@copilot PR comment guardrail

### DIFF
--- a/AI-RULES/LESSONS_LEARNED/2026-02-13-no-copilot-mentions-in-pr-comments.md
+++ b/AI-RULES/LESSONS_LEARNED/2026-02-13-no-copilot-mentions-in-pr-comments.md
@@ -1,0 +1,16 @@
+# 2026-02-13-no-copilot-mentions-in-pr-comments
+
+## Scope
+- Applies only to this repository.
+- Do not copy these rules into downstream-projects.
+
+## Issue
+Mentioning `@copilot` in PR comments can trigger unintended Copilot behavior,
+including autonomous implementation attempts that interfere with the intended
+issue/branch/PR ownership and review loop.
+
+## Prevention
+- Do not mention `@copilot` in PR comments.
+- Use passive polling for Copilot review status instead of comment mentions.
+- If a re-review is needed, use the repository PR review loop workflow without
+  `@copilot` mentions.

--- a/AI-RULES/LESSONS_LEARNED/LESSONS_LEARNED.md
+++ b/AI-RULES/LESSONS_LEARNED/LESSONS_LEARNED.md
@@ -26,6 +26,8 @@ Concrete steps or checks that would have avoided the issue.
 ```
 
 ## Files
+- [2026-02-13-no-copilot-mentions-in-pr-comments.md](2026-02-13-no-copilot-mentions-in-pr-comments.md)
+  - Never mention `@copilot` in PR comments.
 - [2026-02-13-github-issue-newline-escaping.md](2026-02-13-github-issue-newline-escaping.md)
   - Prevent scrambled issue bodies by using `--body-file` for create/edit.
 - [2026-02-08-react-example-robustness.md](2026-02-08-react-example-robustness.md)

--- a/AI-RULES/PR-REVIEW-LOOP.md
+++ b/AI-RULES/PR-REVIEW-LOOP.md
@@ -49,3 +49,4 @@ Repository-standard PR review loop for ai-rules maintenance.
 - Keep PRs focused; do not bundle unrelated repository changes.
 - Never delete review comments to make threads disappear.
 - For invalid findings, leave a clear rationale before resolving.
+- Never mention `@copilot` in PR comments.


### PR DESCRIPTION
Closes #254

## Summary
- add a lessons learned entry that forbids `@copilot` mentions in PR comments
- index the new lesson in `AI-RULES/LESSONS_LEARNED/LESSONS_LEARNED.md`
- add an explicit guardrail to `AI-RULES/PR-REVIEW-LOOP.md`
