### PR TITLE
#265 Move downstream-project LESSONS_LEARNED and DECISIONS under PROJECT

### DIFF
--- a/AGENTS_TEMPLATE.md
+++ b/AGENTS_TEMPLATE.md
@@ -100,12 +100,12 @@ version and adapt behavior as needed:
    Verify transitive reachability for markdown files under `<AI_PROJECT_PATH>`
    using `AI-RULES/DOWNSTREAM-OVERRIDES.md`.
 6. Create a project lessons learned area (recommended):
-   `<AI_ROOT_PATH>/LESSONS_LEARNED/LESSONS_LEARNED.md`
+   `<AI_PROJECT_PATH>/LESSONS_LEARNED/LESSONS_LEARNED.md`
    See `AI-RULES/DOWNSTREAM-PROJECT.md` and
    `AI-RULES/DOWNSTREAM-OVERRIDES.md` for guidance.
 7. Create a project ADR area (recommended):
-   `<AI_ROOT_PATH>/DECISIONS/DECISIONS.md`
-   `<AI_ROOT_PATH>/DECISIONS/ADR-0001-TITLE.md`
+   `<AI_PROJECT_PATH>/DECISIONS/DECISIONS.md`
+   `<AI_PROJECT_PATH>/DECISIONS/ADR-0001-TITLE.md`
    See `AI-RULES/DOWNSTREAM-PROJECT.md` for guidance.
 8. Create entry points for other AI tools:
    - `CLAUDE.md` (Claude Code)
@@ -149,12 +149,12 @@ Local-only update note:
    Verify transitive reachability for markdown files under `<AI_PROJECT_PATH>`
    using `AI-RULES/DOWNSTREAM-OVERRIDES.md`.
 4. Create a project lessons learned area (recommended):
-   `<AI_ROOT_PATH>/LESSONS_LEARNED/LESSONS_LEARNED.md`
+   `<AI_PROJECT_PATH>/LESSONS_LEARNED/LESSONS_LEARNED.md`
    See `AI-RULES/DOWNSTREAM-PROJECT.md` and
    `AI-RULES/DOWNSTREAM-OVERRIDES.md` for guidance.
 5. Create a project ADR area (recommended):
-   `<AI_ROOT_PATH>/DECISIONS/DECISIONS.md`
-   `<AI_ROOT_PATH>/DECISIONS/ADR-0001-TITLE.md`
+   `<AI_PROJECT_PATH>/DECISIONS/DECISIONS.md`
+   `<AI_PROJECT_PATH>/DECISIONS/ADR-0001-TITLE.md`
    See `AI-RULES/DOWNSTREAM-PROJECT.md` for guidance.
 6. Create entry points for other AI tools:
    - `CLAUDE.md` (Claude Code)

--- a/AI-RULES/DOWNSTREAM-PROJECT.md
+++ b/AI-RULES/DOWNSTREAM-PROJECT.md
@@ -27,25 +27,25 @@ Default placeholder mapping for downstream guidance:
 - Keep project-specific AI extensions outside `<AI_RULES_PATH>/` under
   `<AI_PROJECT_PATH>/`.
 - Downstream extension entry point: `<AI_PROJECT_PATH>/AI.md`.
-- Store project lessons learned under `<AI_ROOT_PATH>/LESSONS_LEARNED/` so updates do not overwrite them.
-- Store project ADRs under `<AI_ROOT_PATH>/DECISIONS/` so architecture decisions stay
+- Store project lessons learned under `<AI_PROJECT_PATH>/LESSONS_LEARNED/` so updates do not overwrite them.
+- Store project ADRs under `<AI_PROJECT_PATH>/DECISIONS/` so architecture decisions stay
   with project-owned AI docs, not the vendored subtree.
 
 ## Lessons Learned (project-specific)
-- Create `<AI_ROOT_PATH>/LESSONS_LEARNED/LESSONS_LEARNED.md` with an index and keep entries as
+- Create `<AI_PROJECT_PATH>/LESSONS_LEARNED/LESSONS_LEARNED.md` with an index and keep entries as
   `YYYY-MM-DD-short-title.md`.
 - Keep the scope limited to the downstream-project and update existing entries
   when the issue repeats.
 
 ## Architecture Decision Records (project-specific)
-- Create `<AI_ROOT_PATH>/DECISIONS/DECISIONS.md` as an ADR index.
-- Store individual ADRs as `<AI_ROOT_PATH>/DECISIONS/ADR-0001-TITLE.md`,
-  `<AI_ROOT_PATH>/DECISIONS/ADR-0002-TITLE.md`, and so on.
+- Create `<AI_PROJECT_PATH>/DECISIONS/DECISIONS.md` as an ADR index.
+- Store individual ADRs as `<AI_PROJECT_PATH>/DECISIONS/ADR-0001-TITLE.md`,
+  `<AI_PROJECT_PATH>/DECISIONS/ADR-0002-TITLE.md`, and so on.
 
 ## Entry Points
 - `AGENTS.md` should reference the baseline entry point and downstream extension
   entry point such as `<AI_PROJECT_PATH>/AI.md`.
-- If you use `<AI_ROOT_PATH>/LESSONS_LEARNED/`, reference it from
+- If you use `<AI_PROJECT_PATH>/LESSONS_LEARNED/`, reference it from
   `<AI_PROJECT_PATH>/AI.md` or other local guidance.
 - Verify transitive reachability for all markdown files under
   `<AI_PROJECT_PATH>` using the deterministic docs-only method in

--- a/AI-RULES/UPDATE.md
+++ b/AI-RULES/UPDATE.md
@@ -139,7 +139,8 @@ Use these rules whenever a setup/update/mode-switch flow needs a `REF`.
     - Remove or update references that still point to `AI_PROJECT.md`.
     - Ensure generated/final references point to `<AI_PROJECT_PATH>/AI.md`.
 12. Preserve local extensions and any project-specific rules outside the vendor
-    path, including `<AI_ROOT_PATH>/LESSONS_LEARNED/` if used.
+    path, including `<AI_PROJECT_PATH>/LESSONS_LEARNED/` and
+    `<AI_PROJECT_PATH>/DECISIONS/` if used.
 13. Record the updated version in the destination repository if it tracks versions.
 14. Summarize changes.
 


### PR DESCRIPTION
Closes #265

## Implementation Summary
- Scope: downstream-project path defaults for project-owned lessons learned and ADRs.
- Key changes:
  - switched default lessons path to `<AI_PROJECT_PATH>/LESSONS_LEARNED/` in downstream-project guidance.
  - switched default ADR path to `<AI_PROJECT_PATH>/DECISIONS/` in downstream-project guidance.
  - aligned `AGENTS_TEMPLATE.md` local/git setup examples to the same project-owned locations.
  - updated update-preservation guidance to preserve project-owned `LESSONS_LEARNED` and `DECISIONS` under `<AI_PROJECT_PATH>`.
- Non-goals:
  - no changes to repository-internal `AI-RULES/LESSONS_LEARNED/` used for ai-rules maintenance.

## Validation
- Tests executed:
  - `npx --yes markdownlint-cli2 AGENTS_TEMPLATE.md AI-RULES/DOWNSTREAM-PROJECT.md AI-RULES/UPDATE.md`
- Manual checks:
  - verified no remaining `<AI_ROOT_PATH>/LESSONS_LEARNED` or `<AI_ROOT_PATH>/DECISIONS` placeholders in active downstream guidance.
- Residual risks:
  - downstream projects with custom legacy paths still need case-by-case migration during updates.