### PR TITLE
#269 Add exact-value type guidance for monetary and similar domains

### DIFF
--- a/LANGUAGE/JAVA/JAVA.md
+++ b/LANGUAGE/JAVA/JAVA.md
@@ -33,7 +33,8 @@ Guidance for AI agents implementing and reviewing Java code.
 - If smallest-unit integers are not suitable, prefer dedicated libraries (for
   example Joda-Money or JavaMoney/Moneta) over ad-hoc `BigDecimal` handling.
 - Avoid `new BigDecimal(double)`; if `BigDecimal` is unavoidable, construct
-  from string/valueOf and centralize scale + rounding rules.
+  from `String` for exact decimal values, or use `BigDecimal.valueOf(long)` for
+  whole-number smallest-unit amounts, and centralize scale + rounding rules.
 - Keep unit/currency attached to the amount type to prevent accidental mixing.
 
 ## Nullability and Optional


### PR DESCRIPTION
Closes #269

## Implementation Summary
- Scope: Java guidance for exact-value numeric domains (especially money).
- Key changes:
  - added explicit rule to never use `float`/`double` for exact values.
  - added preference order: smallest-unit integer first, then dedicated money libraries when integer scaling is unsuitable.
  - documented `BigDecimal` constructor pitfall (`new BigDecimal(double)`) and safer construction path.
  - expanded pitfalls, review checklist, and testing guidance for exact-value handling.
- Non-goals:
  - no framework/library-specific monetary API integration changes.

## Validation
- Tests executed:
  - `npx --yes markdownlint-cli2 LANGUAGE/JAVA/JAVA.md`
- Manual checks:
  - verified guidance covers all requested anti-patterns and preferred alternatives.
- Residual risks:
  - teams still need project-specific selection between scaled integers and a dedicated money library.