### PR TITLE
#270 Add repository-root SECURITY.md for GitHub Security Policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -10,15 +10,16 @@ This file defines the repository security disclosure process for GitHub.
 
 ## Supported Versions
 
-| Version | Supported |
+| Version | Support level |
 | --- | --- |
 | `main` branch | Yes |
 | Latest tagged release | Yes |
 | Older tags/releases | Best effort |
 
 ## Reporting a Vulnerability
-1. Use GitHub private vulnerability reporting for this repository:
-   `https://github.com/fabian-barney/ai-rules/security/advisories/new`
+1. Use GitHub private vulnerability reporting for this repository via
+   [GitHub private security advisories](https://github.com/fabian-barney/ai-rules/security/advisories/new).
+   If this policy is reused in another repository, update the owner/repo link accordingly.
 2. Do not open a public GitHub issue for vulnerability details.
 3. Include:
    - affected file/rule and version/ref,


### PR DESCRIPTION
Closes #270

## Implementation Summary
- Scope: add repository-root GitHub Security Policy file.
- Key changes:
  - added `SECURITY.md` at repo root with vulnerability reporting workflow.
  - included explicit demarcation that this file is separate from `SECURITY/SECURITY.md` implementation guidance.
  - documented supported versions and response expectations for reports.
- Non-goals:
  - no changes to technical security rules under `SECURITY/SECURITY.md`.

## Validation
- Tests executed:
  - `npx --yes markdownlint-cli2 SECURITY.md`
- Manual checks:
  - verified file is at repository root so GitHub can surface it as Security Policy.
- Residual risks:
  - response timelines are policy targets and still depend on maintainer availability.