### PR TITLE
#271 Make update cleanup guidance generic (remove AI_PROJECT.md specifics)

### DIFF
--- a/AI-RULES/UPDATE.md
+++ b/AI-RULES/UPDATE.md
@@ -136,8 +136,12 @@ Use these rules whenever a setup/update/mode-switch flow needs a `REF`.
       `<AI_PROJECT_PATH>` using the deterministic docs-only method in
       [AI-RULES/DOWNSTREAM-OVERRIDES.md](DOWNSTREAM-OVERRIDES.md).
 11. Run cleanup for stale legacy references:
-    - Remove or update references that still point to `AI_PROJECT.md`.
-    - Ensure generated/final references point to `<AI_PROJECT_PATH>/AI.md`.
+    - Identify outdated files, directories, and references left from earlier
+      setup/update states.
+    - Remove or update stale items based on current downstream-project
+      structure and preflight findings.
+    - Ensure generated/final references point to the currently resolved
+      baseline and downstream extension entry points.
 12. Preserve local extensions and any project-specific rules outside the vendor
     path, including `<AI_ROOT_PATH>/LESSONS_LEARNED/` if used.
 13. Record the updated version in the destination repository if it tracks versions.


### PR DESCRIPTION
Closes #271

## Implementation Summary
- Scope: remove explicit legacy-file cleanup instructions from update workflow.
- Key changes:
  - replaced specific `AI_PROJECT.md` cleanup bullets in `AI-RULES/UPDATE.md` with generic stale-legacy cleanup guidance.
  - cleanup now requires agents to determine obsolete files/refs from downstream structure and preflight findings.
  - retained requirement that final references resolve to current baseline/downstream entry points.
- Non-goals:
  - no changes to setup mode detection or subtree command flows.

## Validation
- Tests executed:
  - `npx --yes markdownlint-cli2 AI-RULES/UPDATE.md`
- Manual checks:
  - verified no explicit legacy filename is mentioned in the cleanup step.
- Residual risks:
  - generic guidance depends on agent quality for downstream-specific cleanup planning.