### PR TITLE
#284 Improve CONVENTIONS.md: prefer semantic types over basic types

### DIFF
--- a/LANGUAGE/CONVENTIONS.md
+++ b/LANGUAGE/CONVENTIONS.md
@@ -62,11 +62,21 @@ Apply language-standard casing as default:
 - Prefer expanding obscure domain shorthand in public APIs.
 
 ## Identifier Quality Rules
+- Prefer semantic/domain types over raw basic types (`String`, numeric types)
+  when language/runtime/library support makes that practical.
 - Boolean names should read as predicates (`isActive`, `hasAccess`).
 - Collections should use plural names.
-- Temporal values should include units (`timeoutMs`, `expiresAt`).
+- Temporal values should prefer temporal types (for example Java `Duration`)
+  over primitive numerics when feasible.
+- If basic numeric/string fields are still required, keep unit/domain semantics
+  explicit in naming (`timeoutMs`, `expiresAt`, `orderId`).
 - Avoid misleading names that imply stronger guarantees than implementation.
 - Avoid generic names (`data`, `result`, `temp`) unless scope is tiny and clear.
+
+Pragmatic exceptions where basic types may be required:
+- External API/serialization contracts that mandate primitive/string shapes.
+- Performance-critical hot paths where domain-wrapper overhead is material.
+- Interop boundaries where richer types would add unsafe conversion churn.
 
 ## Comment and Documentation Naming
 - Keep comment terminology aligned with code identifiers.
@@ -98,7 +108,19 @@ Don't: retryTimeout = 5
 Do:    retryTimeoutSeconds = 5
 ```
 
-### 3. Generic Naming
+### 3. Prefer Semantic Type (Temporal)
+```text
+Don't: long timeoutMs = 5000;
+Do:    Duration timeout = Duration.ofSeconds(5);
+```
+
+### 4. Prefer Semantic Type (Non-Temporal)
+```text
+Don't: String orderId;
+Do:    OrderId orderId;
+```
+
+### 5. Generic Naming
 ```text
 Don't: process(data)
 Do:    processInvoiceBatch(invoiceBatch)
@@ -109,7 +131,8 @@ Do:    processInvoiceBatch(invoiceBatch)
 - Are naming decisions descriptive and consistent within module scope?
 - Are abbreviations necessary and consistently cased?
 - Are booleans/predicates named semantically?
-- Are numeric/time fields unit-explicit?
+- Are semantic/domain types preferred over raw basic types where feasible?
+- Are unavoidable numeric/time fields unit-explicit?
 - Are multiline formatting and trailing delimiter rules applied consistently?
 - Did refactors keep identifier names aligned across code/comments/docs?
 
@@ -122,5 +145,7 @@ Do:    processInvoiceBatch(invoiceBatch)
 ## Override Notes
 - Language docs may define stricter naming rules (for example TypeScript enum
   member casing).
+- Language docs may also define concrete preferred semantic types (for example
+  Java `Duration` or value objects) that specialize this baseline.
 - Framework/library docs may define local naming idioms, but must remain
   compatible with this baseline and language standards.


### PR DESCRIPTION
Closes #284

## Implementation Summary
- Scope: refine cross-language conventions to prioritize semantic/domain types over raw basic types.
- Key changes:
  - updated `LANGUAGE/CONVENTIONS.md` identifier-quality rules to prefer semantic/domain types first.
  - retained primitive/string naming guidance as fallback when basic types are required.
  - added pragmatic exception guidance (interop/serialization/performance boundaries).
  - added concrete do/don't examples for temporal (`Duration` vs `long timeoutMs`) and non-temporal (`OrderId` vs `String`).
  - aligned override notes to reference language-specific semantic-type specializations.
- Non-goals:
  - no language-specific API-level enforcement changes in this PR.

## Validation
- Tests executed:
  - `npx --yes markdownlint-cli2 "LANGUAGE/CONVENTIONS.md"`
- Manual checks:
  - verified fallback unit-based naming guidance remains present for unavoidable basic types.
- Residual risks:
  - language docs may still need future concrete examples for additional ecosystems.
