### PR TITLE
#289 Harden PR-REVIEW-LOOP merge gate to prevent pre-review merges

### DIFF
--- a/AI-RULES/PR-REVIEW-LOOP.md
+++ b/AI-RULES/PR-REVIEW-LOOP.md
@@ -80,6 +80,7 @@ Repository-standard PR review loop for ai-rules maintenance.
    - no review is currently running for the latest push
    - no new valid findings remain
    - no open review threads remain
+   - `has_required_checks_green = true`
 
 ## Hard Merge Gate (No Exceptions)
 Before merging any PR in this loop, evaluate this gate explicitly. If any item


### PR DESCRIPTION
Closes #289

## Implementation Summary
- Scope: harden PR review-loop merge gate so merges cannot happen before post-push Copilot review completion.
- Key changes:
  - added explicit hard merge gate section with no-exception conditions.
  - added required gate fields (`has_required_checks_green`, `merge_gate_passed`) to the work-item model.
  - documented required-check evaluation as part of state collection.
  - clarified operational hard stops for missing/ambiguous state and stale/pending review.
  - updated completion criteria to require `merge_gate_passed=true`.
- Non-goals:
  - no workflow automation scripting changes; documentation/process hardening only.

## Validation
- Tests executed:
  - `npx --yes markdownlint-cli2 "AI-RULES/PR-REVIEW-LOOP.md"`
- Manual checks:
  - verified merge gate wording explicitly forbids merge on missing/in-progress/stale review states.
- Residual risks:
  - operator discipline is still required until these gates are also tool-enforced.
