### PR TITLE
#291 Define concrete GraphQL mutation in PR review loop

### DIFF
--- a/AI-RULES/PR-REVIEW-LOOP.md
+++ b/AI-RULES/PR-REVIEW-LOOP.md
@@ -57,11 +57,20 @@ Repository-standard PR review loop for ai-rules maintenance.
      continue with the next item:
      - Get raw PR node ID:
        `gh pr view <PR_NUMBER> --json id --jq .id`
+     - Define the GraphQL mutation:
+       ```text
+       mutation RequestCopilotReview($pr: ID!, $bots: String!) {
+         requestReviewsByLogin(
+           input: { pullRequestId: $pr, botLogins: [$bots], union: true }
+         ) {
+           clientMutationId
+         }
+       }
+       ```
+     - Set `MUTATION_QUERY` to the exact mutation text above.
      - Request review from Copilot bot:
-       `gh api graphql -f query="<MUTATION_QUERY>" -f pr="<PR_ID>" -f bots='copilot-pull-request-reviewer'`
-     - Where `<MUTATION_QUERY>` is the complete
-       `requestReviewsByLogin` GraphQL mutation and `<PR_ID>` is the value
-       returned by the previous command.
+       `gh api graphql -f query="$MUTATION_QUERY" -f pr="<PR_ID>" -f bots='copilot-pull-request-reviewer'`
+     - `<PR_ID>` is the value returned by the previous command.
      - Verify a new review request/review appears before judging latest state.
    - Classify each Copilot finding as valid or invalid.
    - Set `has_new_valid_findings` from the current round's classification


### PR DESCRIPTION
## Summary
- replace the undefined <MUTATION_QUERY> placeholder with a concrete equestReviewsByLogin mutation
- keep the existing gh api graphql flow but make it copy-paste executable with MUTATION_QUERY
- retain existing behavior and merge-gate semantics

## Validation
- 
px --yes markdownlint-cli2 AI-RULES/PR-REVIEW-LOOP.md

Closes #291