### PR TITLE
#292 Align React and Angular docs with deep-doc section contract

### DIFF
--- a/FRAMEWORK/ANGULAR.md
+++ b/FRAMEWORK/ANGULAR.md
@@ -2,6 +2,22 @@
 
 Guidance for AI agents implementing and reviewing Angular projects.
 
+## Scope
+- Define Angular-specific component, template, reactive-state, and runtime rules.
+- Apply this file to Angular implementation and review tasks.
+
+## Semantic Dependencies
+- Inherit JavaScript/TypeScript baselines from
+  `LANGUAGE/JAVASCRIPT/JAVASCRIPT.md` and
+  `LANGUAGE/TYPESCRIPT/TYPESCRIPT.md`.
+- Inherit HTML/CSS accessibility and semantics from
+  `LANGUAGE/HTML/HTML.md` and `LANGUAGE/CSS/CSS.md`.
+- Inherit architecture constraints from
+  `ARCHITECTURE/CLEAN_ARCHITECTURE.md` and `ARCHITECTURE/REST.md` where
+  relevant.
+- Inherit cross-cutting constraints from
+  `SECURITY/SECURITY.md`, `TEST/TEST.md`, `CORE/LOGGING.md`.
+
 ## Defaults
 - Follow Angular style guide conventions.
 - Prefer standalone APIs (`bootstrapApplication`, standalone components,
@@ -401,3 +417,8 @@ export class ProfileCardGood {
   signals instead of manual `detectChanges()` defaults.
 - If SSR/hydration is relevant, test browser-global guards and hydration-safe
   render paths.
+
+## Override Notes
+- Project-specific Angular conventions may add stricter structure or delivery
+  constraints, but reactivity clarity, cleanup safety, and SSR/hydration
+  guardrails remain mandatory.

--- a/FRAMEWORK/REACT.md
+++ b/FRAMEWORK/REACT.md
@@ -1,6 +1,19 @@
 # REACT
 
-Guidance for React projects.
+Guidance for AI agents implementing and reviewing React projects.
+
+## Scope
+- Define React-specific component, rendering, and side-effect rules.
+- Apply this file to React implementation and review tasks.
+
+## Semantic Dependencies
+- Inherit JavaScript baseline from `LANGUAGE/JAVASCRIPT/JAVASCRIPT.md`.
+- Apply `LANGUAGE/TYPESCRIPT/TYPESCRIPT.md` as an additional parent when the
+  React codebase uses TypeScript.
+- Inherit HTML/CSS accessibility and semantics from
+  `LANGUAGE/HTML/HTML.md` and `LANGUAGE/CSS/CSS.md`.
+- Inherit cross-cutting constraints from
+  `SECURITY/SECURITY.md`, `TEST/TEST.md`, `CORE/LOGGING.md`.
 
 ## Defaults
 - Use functional components and hooks.
@@ -304,3 +317,7 @@ function WindowWidthGood() {
 - Test behavior under `StrictMode` for duplicate setup/cleanup safety.
 - Test that user-intent side effects happen from handlers, not watcher effects.
 - If SSR/hydration is relevant, test render paths that avoid browser globals.
+
+## Override Notes
+- Project-specific React conventions may add stricter patterns, but effect
+  safety, dependency clarity, and SSR/hydration guardrails remain mandatory.


### PR DESCRIPTION
## Summary
- add explicit ## Scope and ## Semantic Dependencies sections to FRAMEWORK/REACT.md
- add explicit ## Scope and ## Semantic Dependencies sections to FRAMEWORK/ANGULAR.md
- add ## Override Notes sections to both docs to make inheritance/override intent explicit

## Validation
- 
px --yes markdownlint-cli2 FRAMEWORK/REACT.md FRAMEWORK/ANGULAR.md

Closes #292