### PR TITLE
#293 Add Do/Don't sections to SECURITY and TEST baseline docs

### DIFF
--- a/SECURITY/SECURITY.md
+++ b/SECURITY/SECURITY.md
@@ -70,6 +70,25 @@ Security is a non-negotiable baseline across all stacks and domains.
 7. Logging secrets or sensitive personal data.
 8. Disabling security checks for convenience without tracked exceptions.
 
+## Do / Don't Examples
+### 1. Authorization Boundary
+```text
+Don't: trust hidden UI controls or client checks as access control.
+Do:    enforce authorization on trusted server-side boundaries.
+```
+
+### 2. Input Handling
+```text
+Don't: build SQL/HTML/shell output from raw user input strings.
+Do:    validate at boundaries and use parameterized/context-encoded output.
+```
+
+### 3. Secrets and Logs
+```text
+Don't: log bearer tokens, passwords, or full sensitive payloads.
+Do:    redact secrets and log only safe identifiers/reasons.
+```
+
 ## Code Review Checklist
 - Are all external inputs validated at trust boundaries?
 - Are output sinks context-encoded/escaped appropriately?

--- a/TEST/TEST.md
+++ b/TEST/TEST.md
@@ -69,6 +69,25 @@ Defines baseline testing expectations for all stacks and domains.
 6. Ignoring error-path and boundary-condition testing.
 7. Claiming confidence from coverage metrics without assertion quality.
 
+## Do / Don't Examples
+### 1. Behavior Change Coverage
+```text
+Don't: merge a behavior change without updating tests.
+Do:    add/adjust tests for happy path, edge cases, and failure paths.
+```
+
+### 2. Flakiness Control
+```text
+Don't: rerun flaky tests until green and call it stable.
+Do:    quarantine/fix flaky tests and remove nondeterministic dependencies.
+```
+
+### 3. Assertion Quality
+```text
+Don't: rely only on snapshots for critical behavior.
+Do:    use explicit assertions tied to business-relevant outcomes.
+```
+
 ## Code Review Checklist for Testing
 - Do behavior changes include corresponding tests?
 - Are tests deterministic and independent of execution order?


### PR DESCRIPTION
## Summary
- add ## Do / Don't Examples section to SECURITY/SECURITY.md
- add ## Do / Don't Examples section to TEST/TEST.md
- keep examples aligned with existing baseline guidance and checklists

## Validation
- 
px --yes markdownlint-cli2 SECURITY/SECURITY.md TEST/TEST.md

Closes #293