### PR TITLE
298 AGENTS_TEMPLATE.md remove Private repo hint

### DIFF
--- a/AGENTS_TEMPLATE.md
+++ b/AGENTS_TEMPLATE.md
@@ -195,6 +195,3 @@ Use the shared AI rules located at:
 > Note: The Copilot PR Review bot draws context from repository instructions.
 > Keeping `.github/copilot-instructions.md` present and pointed at the baseline
 > increases the chance it uses the same rules.
-
-## Access
-This repository is private; ensure your GitHub account has access.


### PR DESCRIPTION
## Implementation Summary
- Scope: remove outdated visibility guidance from setup template.
- Key changes: deleted the ## Access section that claimed this repository is private.
- Non-goals: no setup workflow or path placeholder changes.

## Validation
- Tests executed: manual markdown diff review.
- Manual checks: verified template still ends cleanly after Copilot note block.
- Residual risks: none expected.

Closes #298