### PR TITLE
300 Make CODE_REVIEW.md and PROGRAMMING.md more clear about inherited constraints

### DIFF
--- a/PROGRAMMING/PROGRAMMING.md
+++ b/PROGRAMMING/PROGRAMMING.md
@@ -11,14 +11,24 @@ Guidance for AI agents executing implementation tasks.
 - Inherit testing constraints from `TEST/TEST.md`.
 - Inherit security/compliance constraints from `SECURITY/SECURITY.md` and
   `COMPLIANCE/COMPLIANCE.md`.
-- Inherit the full cross-cutting baseline per `CORE/RULE_DEPENDENCY_TREE.md`.
-- Inherit language/framework/tool specifics from relevant leaf docs.
+- Inherit dependency order and full cross-cutting baseline from
+  `CORE/RULE_DEPENDENCY_TREE.md`.
+- Resolve constraints through the relevant index docs:
+  `LANGUAGE/LANGUAGE.md`, `DESIGN/DESIGN.md`,
+  `ARCHITECTURE/ARCHITECTURE.md`, `FRAMEWORK/FRAMEWORK.md`,
+  `LIBRARY/LIBRARY.md`, `BUILD_TOOLS/BUILD_TOOLS.md`,
+  `INFRASTRUCTURE/INFRASTRUCTURE.md`, and `CI-CD/CI-CD.md`.
+- Apply corresponding specialized leaf rules under `LANGUAGE/**`,
+  `DESIGN/**`, `ARCHITECTURE/**`, `FRAMEWORK/**`, `LIBRARY/**`,
+  `BUILD_TOOLS/**`, `INFRASTRUCTURE/**`, and `CI-CD/**`.
 
 ## Default Execution Workflow
 1. Confirm behavior goals, acceptance criteria, and scope boundaries.
 2. Locate semantic parent docs using `CORE/RULE_DEPENDENCY_TREE.md` and the
-   relevant index docs (`LANGUAGE/LANGUAGE.md`, `FRAMEWORK/FRAMEWORK.md`,
-   `LIBRARY/LIBRARY.md`, `BUILD_TOOLS/BUILD_TOOLS.md`).
+   relevant index docs (`LANGUAGE/LANGUAGE.md`, `DESIGN/DESIGN.md`,
+   `ARCHITECTURE/ARCHITECTURE.md`, `FRAMEWORK/FRAMEWORK.md`,
+   `LIBRARY/LIBRARY.md`, `BUILD_TOOLS/BUILD_TOOLS.md`,
+   `INFRASTRUCTURE/INFRASTRUCTURE.md`, `CI-CD/CI-CD.md`).
 3. Design minimal-change implementation path.
 4. Implement with explicit error handling and observability where relevant.
 5. Add/update tests and run verification.

--- a/REVIEW/CODE_REVIEW.md
+++ b/REVIEW/CODE_REVIEW.md
@@ -8,8 +8,16 @@ Guidance for AI agents performing code and rules-document reviews.
 
 ## Semantic Dependencies
 - Inherit review-layer boundary from `REVIEW/REVIEW.md`.
-- Inherit all applicable technical constraints from relevant language/framework/
-  library/build/infra docs.
+- Inherit dependency order and cross-cutting baseline from
+  `CORE/RULE_DEPENDENCY_TREE.md`.
+- Resolve applicable constraints through index docs:
+  `LANGUAGE/LANGUAGE.md`, `DESIGN/DESIGN.md`,
+  `ARCHITECTURE/ARCHITECTURE.md`, `FRAMEWORK/FRAMEWORK.md`,
+  `LIBRARY/LIBRARY.md`, `BUILD_TOOLS/BUILD_TOOLS.md`,
+  `INFRASTRUCTURE/INFRASTRUCTURE.md`, and `CI-CD/CI-CD.md`.
+- Apply corresponding specialized leaf rules under `LANGUAGE/**`,
+  `DESIGN/**`, `ARCHITECTURE/**`, `FRAMEWORK/**`, `LIBRARY/**`,
+  `BUILD_TOOLS/**`, `INFRASTRUCTURE/**`, and `CI-CD/**`.
 - Inherit security/testing/compliance constraints and priority direction from
   `SECURITY/SECURITY.md`, `TEST/TEST.md`, `COMPLIANCE/COMPLIANCE.md`.
 - Severity levels are defined by this document's local severity model.


### PR DESCRIPTION
## Implementation Summary
- Scope: clarify inheritance guidance in review/programming overlays.
- Key changes:
  - REVIEW/CODE_REVIEW.md: replaced vague inheritance wording with explicit index docs and /** leaf-directory scope.
  - PROGRAMMING/PROGRAMMING.md: added explicit index docs + /** leaf-directory scope and expanded default workflow step 2 to include architecture/design/infra/CI-CD indexes.
- Non-goals: no behavior changes outside these two overlay docs.

## Validation
- Tests executed: manual markdown diff review.
- Manual checks: verified references align with existing repository index files.
- Residual risks: markdownlint CLI unavailable locally, so lint was not executed.

Closes #300