### PR TITLE
304 Addition to PR-REVIEW-LOOP.md

### DIFF
--- a/AI-RULES/PR-REVIEW-LOOP.md
+++ b/AI-RULES/PR-REVIEW-LOOP.md
@@ -26,6 +26,17 @@ Repository-standard PR review loop for ai-rules maintenance.
   multiple issues or PRs.
 - After these one-time decisions are captured, run unattended unless blocked.
 
+## Session Preference Application
+- Apply `RUN_REVIEW_LOOP` before starting this loop:
+  - If `RUN_REVIEW_LOOP=true`, execute this document's loop.
+  - If `RUN_REVIEW_LOOP=false`, do not execute the loop; report that review
+    loop execution is intentionally skipped for this session.
+- Apply `IMPLEMENT_AFTER_PLAN` in workflows that include a planning phase:
+  - If `IMPLEMENT_AFTER_PLAN=true`, continue from planning into
+    implementation/review-loop execution without additional user prompts.
+  - If `IMPLEMENT_AFTER_PLAN=false`, stop after planning and wait for explicit
+    user instruction before implementation and review-loop execution.
+
 ## Work Item Model
 - Treat each issue/PR pair as one independent work item.
 - Track per item:


### PR DESCRIPTION
## Implementation Summary
- Scope: update PR review-loop guidance for session-start autonomy and clarity.
- Key changes:
  - Replaced merge-only session question section with a broader Session Entry Preferences section.
  - Added explicit ask-once rules (only when prompt is unclear) for:
    - running the code-review loop,
    - immediate implementation after planning,
    - merge-after-clean-loop.
  - Added Copilot review latency note (often ~5 minutes) while preserving no-fixed-wait gating.
- Non-goals: no changes outside AI-RULES/PR-REVIEW-LOOP.md.

## Validation
- Tests executed: manual markdown diff and content consistency check.
- Manual checks: verified existing no-fixed-wait guardrail remains in place.
- Residual risks: local markdownlint CLI unavailable.

Closes #304