### PR TITLE
308 change default base dir from docs/ai to ai only

### DIFF
--- a/AGENTS_TEMPLATE.md
+++ b/AGENTS_TEMPLATE.md
@@ -17,7 +17,7 @@ To switch modes later, use "mode ai-rules local" or "mode ai-rules git".
 
 ### Paths
 Use these placeholders consistently:
-- `<AI_ROOT_PATH>` = `docs/ai`
+- `<AI_ROOT_PATH>` = `ai`
 - `<AI_RULES_PATH>` = `<AI_ROOT_PATH>/AI-RULES`
 - `<AI_PROJECT_PATH>` = `<AI_ROOT_PATH>/PROJECT`
 
@@ -170,9 +170,9 @@ Git update note:
 
 ## Entry Point Templates
 Note: Replace placeholders with actual paths:
-- `<AI_ROOT_PATH>` => `docs/ai`
-- `<AI_RULES_PATH>` => `docs/ai/AI-RULES`
-- `<AI_PROJECT_PATH>` => `docs/ai/PROJECT`
+- `<AI_ROOT_PATH>` => `ai`
+- `<AI_RULES_PATH>` => `ai/AI-RULES`
+- `<AI_PROJECT_PATH>` => `ai/PROJECT`
 
 ### CLAUDE.md
 ```

--- a/AI-RULES/DOWNSTREAM-OVERRIDES.md
+++ b/AI-RULES/DOWNSTREAM-OVERRIDES.md
@@ -13,10 +13,10 @@ be authored by AI agents.
   - `<AI_RULES_PATH>`
   - `<AI_PROJECT_PATH>`
 - Default mapping:
-  - `<AI_ROOT_PATH>=docs/ai`
+  - `<AI_ROOT_PATH>=ai`
   - `<AI_RULES_PATH>=<AI_ROOT_PATH>/AI-RULES`
   - `<AI_PROJECT_PATH>=<AI_ROOT_PATH>/PROJECT`
-- Never hardcode `docs/ai` when placeholders are available.
+- Never hardcode `ai` when placeholders are available.
 
 ## Extension Semantics and Conflict Precedence
 - Baseline rules under `<AI_RULES_PATH>` remain authoritative defaults.

--- a/AI-RULES/DOWNSTREAM-PROJECT.md
+++ b/AI-RULES/DOWNSTREAM-PROJECT.md
@@ -10,7 +10,7 @@ Legacy wording "consuming project" means the same thing.
 
 ## Path Placeholders
 Default placeholder mapping for downstream guidance:
-- `<AI_ROOT_PATH>` = `docs/ai`
+- `<AI_ROOT_PATH>` = `ai`
 - `<AI_RULES_PATH>` = `<AI_ROOT_PATH>/AI-RULES`
 - `<AI_PROJECT_PATH>` = `<AI_ROOT_PATH>/PROJECT`
 

--- a/AI-RULES/UPDATE.md
+++ b/AI-RULES/UPDATE.md
@@ -25,8 +25,8 @@ Use these rules whenever a setup/update/mode-switch flow needs a `REF`.
 
 ## Update Steps (run when requested)
 1. Locate the vendored ai-rules path and entry point from `AGENTS.md` or README.
-   - Set `<AI_ROOT_PATH>` to the repo-relative ai docs root (for example
-     `docs/ai`).
+   - Set `<AI_ROOT_PATH>` to the repo-relative ai root path (for example
+     `ai`).
    - Set `<AI_RULES_PATH>` to the baseline path (for example
      `<AI_ROOT_PATH>/AI-RULES`).
    - Set `<AI_PROJECT_PATH>` to the downstream extension path (for example
@@ -35,9 +35,9 @@ Use these rules whenever a setup/update/mode-switch flow needs a `REF`.
    - Every time this guide shows `<AI_PROJECT_PATH>`, replace it with that real
      path.
    - For `.git/info/exclude`, the matching directory entry is `/<AI_RULES_PATH>/`
-     (for example `/docs/ai/AI-RULES/`).
+     (for example `/ai/AI-RULES/`).
    - For downstream extensions in local mode, the matching directory entry is
-     `/<AI_PROJECT_PATH>/` (for example `/docs/ai/PROJECT/`).
+     `/<AI_PROJECT_PATH>/` (for example `/ai/PROJECT/`).
 2. Enforce a clean-working-tree precondition before subtree operations:
    - Run `git status --porcelain`.
    - If output is empty, continue.
@@ -52,7 +52,7 @@ Use these rules whenever a setup/update/mode-switch flow needs a `REF`.
      - `TRACKED_SUBTREE=true` if `git ls-files -- "<AI_RULES_PATH>/AI.md"` returns a tracked file.
      - `LOCAL_HINT=true` if `.git/info/exclude` contains the subtree directory
        entry `/<AI_RULES_PATH>/` (replace with the real path; example:
-       `/docs/ai/AI-RULES/`).
+       `/ai/AI-RULES/`).
        Companion excludes (for example `/AGENTS.md`, `/<AI_PROJECT_PATH>/`,
        `/CLAUDE.md`, `/.github/copilot-instructions.md`) are optional and do not
        affect `LOCAL_HINT`.
@@ -168,7 +168,7 @@ Steps:
       Note: `<AI_PROJECT_PATH>/` is shared/tracked in git mode. Switching to
       local intentionally converts it to local-only (untracked).
    - Add the local excludes to `.git/info/exclude` (keep the file intact):
-     (Replace `/<AI_RULES_PATH>/` with the real path; example: `/docs/ai/AI-RULES/`.)
+     (Replace `/<AI_RULES_PATH>/` with the real path; example: `/ai/AI-RULES/`.)
      /<AI_RULES_PATH>/
      /<AI_PROJECT_PATH>/
      /AGENTS.md
@@ -182,7 +182,7 @@ Steps:
 3. If switching to git:
    - If already git, stop.
    - Remove the ai-rules entries from `.git/info/exclude` (keep the file intact):
-     (Replace `/<AI_RULES_PATH>/` with the real path; example: `/docs/ai/AI-RULES/`.)
+     (Replace `/<AI_RULES_PATH>/` with the real path; example: `/ai/AI-RULES/`.)
      /<AI_RULES_PATH>/
      /<AI_PROJECT_PATH>/
      /AGENTS.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## Unreleased
+- Changed the default downstream base directory placeholder from `docs/ai` to
+  `ai` across setup/template/update guidance.
 
 ## [v4.5.0] - 2026-02-15
 - Added session entry preferences and execution controls in
@@ -105,14 +107,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Clarified update/setup path placeholder handling, including copy-paste-safe
   `.git/info/exclude` examples.
 - Added readability guidance forbidding nested/chained ternary expressions.
-- Added downstream-project ADR guidance under `docs/ai/DECISIONS/` and
+- Added downstream-project ADR guidance under `<AI_PROJECT_PATH>/DECISIONS/` and
   clarified downstream-project terminology.
 - Clarified scope boundaries between repository governance files and
   downstream-project operational guidance.
 
 ## [v3.0.0] - 2026-02-05
 - Breaking: flattened repo layout with `AI.md` at the repo root and subtree prefix
-  guidance updated to `docs/ai/AI-RULES`.
+  guidance updated to `<AI_RULES_PATH>`.
 - Added PROGRAMMING, PLAN, and CODE_REVIEW guidance with stricter review expectations.
 - Added downstream-project guidance for lessons learned placement and maintenance rules.
 - Added test fixture separation guidance and markdownlint hygiene updates.


### PR DESCRIPTION
## Implementation Summary
- Scope: change default downstream base directory placeholder from `docs/ai` to `ai`.
- Key changes:
  - Updated default placeholder mappings and example paths in setup/update/downstream docs.
  - Normalized stale hardcoded historical changelog references to placeholders where appropriate.
- Non-goals:
  - No changes to review-loop execution behavior in this PR.

## Validation
- Tests executed:
  - `npx --yes markdownlint-cli2 "**/*.md" "!**/node_modules/**"`
- Manual checks:
  - Searched for hardcoded `docs/ai` references and confirmed only intentional mention remains in the Unreleased changelog delta.
- Residual risks:
  - Downstream repos that already use custom paths are unaffected because guidance remains placeholder-based.

Closes #308
