### PR TITLE
309 Inconsistent formatting of CHANGELOG.md sub-headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project are documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+Sub-heading template:
+- Unreleased section: `## Unreleased`
+- Released versions: `## [vX.Y.Z] - YYYY-MM-DD`
+
 ## Unreleased
 - Changed the default downstream base directory placeholder from `docs/ai` to
   `ai` across setup/template/update guidance.


### PR DESCRIPTION
## Implementation Summary
- Scope: standardize changelog sub-heading guidance for future and historical consistency checks.
- Key changes:
  - Added an explicit `Sub-heading template` section to `CHANGELOG.md`.
  - Documented canonical forms for both `Unreleased` and released version headings.
- Non-goals:
  - No structural content rewrites outside heading-format guidance.

## Validation
- Tests executed:
  - `npx --yes markdownlint-cli2 "**/*.md" "!**/node_modules/**"`
- Manual checks:
  - Verified changelog heading style remains `## [vX.Y.Z] - YYYY-MM-DD` for release entries.
- Residual risks:
  - Historical entries are already normalized; this change primarily prevents future drift.

Closes #309
