### PR TITLE
314 Normalize GitHub release-note sub-heading format in release ai-rules workflow

### DIFF
--- a/AI-RULES/RELEASE.md
+++ b/AI-RULES/RELEASE.md
@@ -31,6 +31,9 @@ Version selection:
 6. Create an annotated tag (for example `v4.5.0`).
 7. Push `main` and the tag to GitHub.
 8. Create a GitHub Release using the changelog notes.
+   - Release notes must start with this exact sub-heading template:
+     `## [vX.Y.Z] - YYYY-MM-DD`
+   - Keep bullet content unchanged when normalizing only sub-heading format.
 9. Verify the release page and tag exist.
 
 ## Notes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ Sub-heading template:
   issue branch + PR/MR flow, and explicit completion status reporting fields.
 - Added repository PR-loop preconditions to consume shared plan/VCS rules
   without redefining downstream-project guidance scope.
+- Standardized release-note sub-heading formatting guidance in
+  `AI-RULES/RELEASE.md` to enforce a single canonical heading template.
 
 ## [v4.5.0] - 2026-02-15
 - Added session entry preferences and execution controls in


### PR DESCRIPTION
## Implementation Summary
- Scope: normalize GitHub release-note sub-heading formatting consistency only.
- Key changes:
  - Added canonical release-note heading rule to `AI-RULES/RELEASE.md`: `## [vX.Y.Z] - YYYY-MM-DD`.
  - Added changelog note documenting release-note sub-heading standardization.
  - Normalized existing GitHub release notes for tags `v2.2.0` through `v4.5.0` to the canonical sub-heading format.
- Non-goals:
  - No changes to release bullet content, ordering, or wording.

## Validation
- Tests executed:
  - `npx --yes markdownlint-cli2 "**/*.md" "!**/node_modules/**"`
- Manual checks:
  - Verified current release pages now use canonical heading format:
    - `v4.5.0`: `## [v4.5.0] - 2026-02-15`
    - `v4.4.0`: `## [v4.4.0] - 2026-02-14`
    - `v4.3.0`: `## [v4.3.0] - 2026-02-13`
    - `v4.2.0`: `## [v4.2.0] - 2026-02-08`
    - `v4.1.0`: `## [v4.1.0] - 2026-02-07`
    - `v4.0.0`: `## [v4.0.0] - 2026-02-07`
    - `v3.0.1`: `## [v3.0.1] - 2026-02-06`
    - `v3.0.0`: `## [v3.0.0] - 2026-02-05`
    - `v2.2.0`: `## [v2.2.0] - 2026-02-04`
- Residual risks:
  - Future inconsistency risk remains only if release process bypasses documented template.

Closes #314
