### PR TITLE
316 Fix duplicated/triplicated top headings in GitHub release notes

### DIFF
--- a/AI-RULES/RELEASE.md
+++ b/AI-RULES/RELEASE.md
@@ -33,6 +33,8 @@ Version selection:
 8. Create a GitHub Release using the changelog notes.
    - Release notes must start with this exact sub-heading template:
      `## [vX.Y.Z] - YYYY-MM-DD`
+   - If normalizing an existing release, remove any pre-existing top markdown
+     heading lines before adding the canonical sub-heading.
    - Keep bullet content unchanged when normalizing only sub-heading format.
 9. Verify the release page and tag exist.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ Sub-heading template:
   without redefining downstream-project guidance scope.
 - Standardized release-note sub-heading formatting guidance in
   `AI-RULES/RELEASE.md` to enforce a single canonical heading template.
+- Fixed duplicated/triplicated release-note top headings by deduplicating
+  existing GitHub release-note sub-headings and documenting heading-stripping
+  behavior in `AI-RULES/RELEASE.md`.
 
 ## [v4.5.0] - 2026-02-15
 - Added session entry preferences and execution controls in


### PR DESCRIPTION
## Implementation Summary
- Scope: fix duplicated/triplicated top sub-headings in GitHub release notes only.
- Key changes:
  - Deduplicated existing release-note headings so each release starts with exactly one canonical line: `## [vX.Y.Z] - YYYY-MM-DD`.
  - Added a guardrail in `AI-RULES/RELEASE.md` to remove pre-existing top heading lines before adding the canonical heading when normalizing existing releases.
  - Added an Unreleased changelog note documenting the deduplication fix.
- Non-goals:
  - No non-heading release-note content changes.

## Validation
- Tests executed:
  - `npx --yes markdownlint-cli2 "**/*.md" "!**/node_modules/**"`
- Manual checks:
  - Verified release pages no longer have stacked heading lines.
  - Script check confirms no release has a second heading line directly below the canonical top heading.
- Residual risks:
  - None specific beyond future manual edits bypassing documented release guidance.

Closes #316
