### PR TITLE
318 Remove one-time release-note normalization guidance from RELEASE.md

### DIFF
--- a/AI-RULES/RELEASE.md
+++ b/AI-RULES/RELEASE.md
@@ -33,9 +33,6 @@ Version selection:
 8. Create a GitHub Release using the changelog notes.
    - Release notes must start with this exact sub-heading template:
      `## [vX.Y.Z] - YYYY-MM-DD`
-   - If normalizing an existing release, remove any pre-existing top markdown
-     heading lines before adding the canonical sub-heading.
-   - Keep bullet content unchanged when normalizing only sub-heading format.
 9. Verify the release page and tag exist.
 
 ## Notes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,8 +18,7 @@ Sub-heading template:
 - Standardized release-note sub-heading formatting guidance in
   `AI-RULES/RELEASE.md` to enforce a single canonical heading template.
 - Fixed duplicated/triplicated release-note top headings by deduplicating
-  existing GitHub release-note sub-headings and documenting heading-stripping
-  behavior in `AI-RULES/RELEASE.md`.
+  existing GitHub release-note sub-headings.
 
 ## [v4.5.0] - 2026-02-15
 - Added session entry preferences and execution controls in


### PR DESCRIPTION
## Implementation Summary
- Scope: remove one-time normalization guidance from steady-state release instructions.
- Key changes:
  - Removed normalization-specific wording from `AI-RULES/RELEASE.md`.
  - Kept only canonical heading template requirement for future releases.
  - Updated Unreleased changelog entry to stop implying recurring normalization guidance.
- Non-goals:
  - No change to release-note content or release workflow beyond guidance wording.

## Validation
- Tests executed:
  - `npx --yes markdownlint-cli2 "**/*.md" "!**/node_modules/**"`
- Manual checks:
  - Verified `AI-RULES/RELEASE.md` now contains only steady-state sub-heading template rule.
- Residual risks:
  - None beyond normal doc drift risk.

Closes #318
