### PR TITLE
Issue #320: Advise update ai-rules workflow for structure changes

### DIFF
--- a/AI-RULES/UPDATE.md
+++ b/AI-RULES/UPDATE.md
@@ -90,6 +90,12 @@ Use these rules whenever a setup/update/mode-switch flow needs a `REF`.
        including `TARGET_VERSION`.
    - Identify breaking or behavior-changing entries (for example path renames,
      entry-point changes, setup/update workflow changes, mode semantics changes).
+   - Compare target-version directory/file structure expectations for both:
+     - baseline vendor content under `<AI_RULES_PATH>/`
+     - downstream overrides under `<AI_PROJECT_PATH>/`
+   - Derive required structure-migration actions ad-hoc from those detected
+     differences and the current downstream-project state. Do not rely on a
+     fixed migration checklist for structure changes in this ruleset.
    - Adapt the setup/update commands and file operations before execution.
    - Summarize the detected changes and adapted execution plan before proceeding.
    - If the target-version docs cannot be inspected, stop and ask the user how
@@ -140,6 +146,9 @@ Use these rules whenever a setup/update/mode-switch flow needs a `REF`.
       setup/update states.
     - Remove or update stale items based on current downstream-project
       structure and preflight findings.
+    - Validate that entry and ignore files no longer contain stale path
+      references (for example `AGENTS.md`, `CLAUDE.md`,
+      `.github/copilot-instructions.md`, and `.git/info/exclude`).
     - Ensure generated/final references point to the currently resolved
       baseline and downstream extension entry points.
 12. Preserve local extensions and any project-specific rules outside the vendor
@@ -147,6 +156,22 @@ Use these rules whenever a setup/update/mode-switch flow needs a `REF`.
     `<AI_PROJECT_PATH>/DECISIONS/` if used.
 13. Record the updated version in the destination repository if it tracks versions.
 14. Summarize changes.
+
+## Completion Gates (required before closing an update)
+- Structure alignment gate:
+  - The downstream-project directory/file layout matches target-version
+    expectations from preflight for both `<AI_RULES_PATH>/` and
+    `<AI_PROJECT_PATH>/`.
+- Git-subtree location gate (git mode only):
+  - `<AI_RULES_PATH>/AI.md` is tracked.
+  - No stale tracked ai-rules vendor path from an old structure remains.
+- Stale-reference gate:
+  - No stale path reference remains in baseline/downstream entry files or ignore
+    files (at minimum `AGENTS.md`, `CLAUDE.md`,
+    `.github/copilot-instructions.md`, `.git/info/exclude`).
+- Final consistency gate:
+  - Baseline and downstream entry points resolve to the currently installed
+    structure and all preflight-detected migration items are complete.
 
 ## Mode Switch (when requested)
 Prompt Examples:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ Sub-heading template:
 - Released versions: `## [vX.Y.Z] - YYYY-MM-DD`
 
 ## Unreleased
+- Strengthened `AI-RULES/UPDATE.md` with explicit structure-adaptation guidance
+  for baseline and downstream override directory/file changes, requiring ad-hoc
+  migration planning from preflight findings instead of a fixed checklist.
+- Added required update completion gates for structure alignment, git-subtree
+  location validation (git mode), and stale-reference cleanup in entry/ignore
+  files.
 
 ## [v4.6.0] - 2026-02-15
 - Changed the default downstream base directory placeholder from `docs/ai` to


### PR DESCRIPTION
Closes #320

## Implementation Summary
- Scope:
  - Update the downstream update workflow guidance in `AI-RULES/UPDATE.md` to handle structure changes for baseline and downstream overrides.
- Key changes:
  - Added explicit preflight guidance to compare target-version structure expectations for both `<AI_RULES_PATH>` and `<AI_PROJECT_PATH>`.
  - Added requirement to derive migration steps ad-hoc from detected differences rather than following a fixed structure-migration checklist.
  - Added stale-reference cleanup checks for entry and ignore files.
  - Added explicit completion gates for structure alignment, git-subtree placement (git mode), stale-reference cleanup, and final consistency.
  - Recorded the change under `CHANGELOG.md` Unreleased.
- Non-goals:
  - No subtree command behavior changes.
  - No setup-template restructuring outside the update workflow guidance.

## Validation
- Tests executed:
  - `npx --yes markdownlint-cli2 CHANGELOG.md AI-RULES/UPDATE.md`
- Manual checks:
  - Reviewed doc diff to ensure all issue requirements are covered.
- Residual risks:
  - Guidance quality depends on downstream agents correctly performing and applying preflight analysis.