### PR TITLE
#324 Enforce full ruleset-read gates in PLAN/PROGRAMMING/CODE_REVIEW

### DIFF
--- a/PLAN/PLAN.md
+++ b/PLAN/PLAN.md
@@ -22,12 +22,34 @@ Guidance for AI agents creating implementation plans.
   `TEST/TEST.md`, `SECURITY/SECURITY.md`, and `COMPLIANCE/COMPLIANCE.md`.
 - Inherit workflow constraints from `CORE/VERSION_CONTROL_SYSTEM.md`.
 
+## Ruleset Read Gate (Mandatory)
+- Start every planning task by reading the complete ai-rules ruleset.
+- "Complete ai-rules ruleset" means every Markdown file transitively reachable
+  from the baseline entry point `AI.md`.
+- In downstream-projects, also read every Markdown file transitively reachable
+  from the downstream extension entry point described in
+  `AI-RULES/DOWNSTREAM-PROJECT.md`.
+- Do not skip reachable Markdown files and do not pick files ad-hoc.
+- After the full read is complete, irrelevant rules may be removed from active
+  context.
+
 ## Planning Requirement (Mandatory)
 - Create a plan before starting implementation for every implementation task.
 - The plan may be lightweight for low-risk, trivial changes, but it must still
   be decision-complete for its scope and risk while stating required elements
   tersely.
 - Do not start implementation when no plan exists.
+
+## Plan Step Ordering Gates (Mandatory)
+- Every plan must include a ruleset-read step as the very first task.
+- The first task must require reading the complete ai-rules ruleset as defined
+  in `Ruleset Read Gate (Mandatory)`.
+- No other planning or implementation task may appear before that first step.
+- Every plan must include a final task that re-reads the complete ai-rules
+  ruleset and verifies the current planned/implemented changes still conform.
+- If non-conformance is found during that final task, corrective updates are
+  mandatory before the plan can be marked complete.
+- This end-of-plan conformance check is a hard quality gate.
 
 ## Decision-Complete Plan Requirements
 A plan must specify (at depth appropriate to scope/risk):
@@ -101,6 +123,8 @@ Do:    update parent baselines first, then child specializations.
 
 ## Plan Review Checklist
 - Is the plan decision-complete and implementation-ready?
+- Does the plan start with the mandatory complete-ruleset-read task?
+- Does the plan end with the mandatory complete-ruleset-read conformance gate?
 - Are scope and success criteria explicit?
 - Are semantic dependencies and ordering correct?
 - Are risks, mitigations, and rollback steps captured?

--- a/PROGRAMMING/PROGRAMMING.md
+++ b/PROGRAMMING/PROGRAMMING.md
@@ -22,8 +22,20 @@ Guidance for AI agents executing implementation tasks.
   `DESIGN/**`, `ARCHITECTURE/**`, `FRAMEWORK/**`, `LIBRARY/**`,
   `BUILD_TOOLS/**`, `INFRASTRUCTURE/**`, and `CI-CD/**`.
 
+## Ruleset Read Gate (Mandatory)
+- Start every programming task by reading the complete ai-rules ruleset.
+- "Complete ai-rules ruleset" means every Markdown file transitively reachable
+  from the baseline entry point `AI.md`.
+- In downstream-projects, also read every Markdown file transitively reachable
+  from the downstream extension entry point described in
+  `AI-RULES/DOWNSTREAM-PROJECT.md`.
+- Do not skip reachable Markdown files and do not pick files ad-hoc.
+- After the full read is complete, irrelevant rules may be removed from active
+  context.
+
 ## Default Execution Workflow
 1. Verify hard preconditions before implementation:
+   - The ruleset read gate in this file has been completed.
    - A plan exists (see `PLAN/PLAN.md`).
    - The work is mapped to an issue/ticket.
    - Work is on a dedicated non-default branch for that issue/ticket.

--- a/REVIEW/CODE_REVIEW.md
+++ b/REVIEW/CODE_REVIEW.md
@@ -22,6 +22,17 @@ Guidance for AI agents performing code and rules-document reviews.
   `SECURITY/SECURITY.md`, `TEST/TEST.md`, `COMPLIANCE/COMPLIANCE.md`.
 - Severity levels are defined by this document's local severity model.
 
+## Ruleset Read Gate (Mandatory)
+- Start every review task by reading the complete ai-rules ruleset.
+- "Complete ai-rules ruleset" means every Markdown file transitively reachable
+  from the baseline entry point `AI.md`.
+- In downstream-projects, also read every Markdown file transitively reachable
+  from the downstream extension entry point described in
+  `AI-RULES/DOWNSTREAM-PROJECT.md`.
+- Do not skip reachable Markdown files and do not pick files ad-hoc.
+- After the full read is complete, irrelevant rules may be removed from active
+  context.
+
 ## Review Priority Order
 1. Correctness and regression risk.
 2. Security, privacy, and compliance.


### PR DESCRIPTION
## Implementation Summary
- Scope:
  - Enforce issue #324 requirements in planning, programming, and review overlays.
- Key changes:
  - Added `Ruleset Read Gate (Mandatory)` to:
    - `PLAN/PLAN.md`
    - `PROGRAMMING/PROGRAMMING.md`
    - `REVIEW/CODE_REVIEW.md`
  - Added `Plan Step Ordering Gates (Mandatory)` in `PLAN/PLAN.md` requiring:
    - first plan task = complete ruleset read
    - final plan task = complete ruleset re-read + conformance check quality gate
  - Updated plan checklist with explicit first/last gate checks.
- Non-goals:
  - No structural changes to dependency tree/index files.

## Validation
- Tests executed:
  - `npx --yes markdownlint-cli2 PLAN/PLAN.md PROGRAMMING/PROGRAMMING.md REVIEW/CODE_REVIEW.md`
- Manual checks:
  - Verified required sections and wording alignment with downstream entrypoint guidance.
- Residual risks:
  - Rule strictness increases process overhead; intentional per issue #324.

Closes #324