### PR TITLE
#328 Align ai-rules mode-switch push behavior to explicit confirmation

### DIFF
--- a/AI-RULES/UPDATE.md
+++ b/AI-RULES/UPDATE.md
@@ -223,8 +223,9 @@ Steps:
      `git subtree add --prefix "<AI_RULES_PATH>" https://github.com/fabian-barney/ai-rules.git <REF> --squash`
    - Create any missing entry points (for example `AGENTS.md` final references,
      `<AI_PROJECT_PATH>/AI.md`, `CLAUDE.md`, and
-     `.github/copilot-instructions.md`), ensure they are tracked, then commit
-     and push.
+     `.github/copilot-instructions.md`), ensure they are tracked, then commit.
+   - Ask the user whether to push this commit, and only push if they explicitly
+     confirm.
 
 ## Expectations
 - Prefer tagged releases unless explicitly asked for a branch.


### PR DESCRIPTION
## Implementation Summary
- Scope: Align mode-switch push behavior in `AI-RULES/UPDATE.md`.
- Key changes:
  - Updated git-mode switch instructions to commit first, then require explicit user confirmation before push.
  - Kept wording consistent with existing push-confirmation guidance in the same document.
- Non-goals:
  - No changes to subtree command semantics.

## Validation
- Tests executed:
  - `npx --yes markdownlint-cli2 "**/*.md"`
- Manual checks:
  - Verified mode-switch section now applies explicit push confirmation in both directions.
- Residual risks:
  - None identified for this scoped doc-only change.

Closes #328
