### PR TITLE
#329 Fix PowerShell-breaking line continuation in update mode-switch command

### DIFF
--- a/AI-RULES/UPDATE.md
+++ b/AI-RULES/UPDATE.md
@@ -186,9 +186,10 @@ Steps:
      control for this repo. This requires a commit.
    - Remove tracked ai-rules paths but keep files:
       ```
-      git rm -r --cached --ignore-unmatch -- "<AI_RULES_PATH>" "<AI_PROJECT_PATH>" \
-        "AGENTS.md" "CLAUDE.md" ".github/copilot-instructions.md"
+      git rm -r --cached --ignore-unmatch -- "<AI_RULES_PATH>" "<AI_PROJECT_PATH>" "AGENTS.md" "CLAUDE.md" ".github/copilot-instructions.md"
       ```
+      Use the single-line form above for shell portability (including
+      PowerShell).
       This must succeed even when optional entry-point files are absent.
       Note: `<AI_PROJECT_PATH>/` is shared/tracked in git mode. Switching to
       local intentionally converts it to local-only (untracked).


### PR DESCRIPTION
## Implementation Summary
- Scope: Fix shell portability in the mode-switch `git rm` instruction.
- Key changes:
  - Replaced trailing-backslash multi-line command with a single-line command.
  - Added explicit portability note that this format is safe for PowerShell.
- Non-goals:
  - No changes to command behavior or flags.

## Validation
- Tests executed:
  - `npx --yes markdownlint-cli2 "**/*.md"`
- Manual checks:
  - Confirmed the command no longer relies on bash line continuation.
- Residual risks:
  - None identified for this scoped documentation update.

Closes #329
