### PR TITLE
#330 Harden docs-check workflow with pinned actions and explicit permissions

### DIFF
--- a/.github/workflows/docs-check.yml
+++ b/.github/workflows/docs-check.yml
@@ -5,12 +5,15 @@ on:
   push:
     branches: [ main ]
 
+permissions:
+  contents: read
+
 jobs:
   markdownlint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: DavidAnson/markdownlint-cli2-action@v16
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      - uses: DavidAnson/markdownlint-cli2-action@b4c9feab76d8025d1e83c653fa3990936df0e6c8
         with:
           globs: |
             **/*.md
@@ -20,7 +23,7 @@ jobs:
   linkcheck:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: lycheeverse/lychee-action@v2.0.2
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      - uses: lycheeverse/lychee-action@7cd0af4c74a61395d455af97419279d86aafaede
         with:
           args: --no-progress --verbose --exclude-mail "**/*.md"


### PR DESCRIPTION
## Implementation Summary
- Scope: Harden docs quality workflow security posture.
- Key changes:
  - Added explicit workflow permissions: `contents: read`.
  - Pinned all third-party actions to immutable commit SHAs.
- Non-goals:
  - No behavior change to markdown/link checks.

## Validation
- Tests executed:
  - `npx --yes yaml-lint .github/workflows/docs-check.yml`
  - `npx --yes markdownlint-cli2 "**/*.md"`
- Manual checks:
  - Verified jobs and step structure remain unchanged except action refs/permissions.
- Residual risks:
  - Pinned SHAs should be updated periodically as part of dependency maintenance.

Closes #330
