### PR TITLE
396 Resolve historical unresolved Copilot review threads

### DIFF
--- a/AGENTS_TEMPLATE.md
+++ b/AGENTS_TEMPLATE.md
@@ -66,7 +66,7 @@ version and adapt behavior as needed:
 
 ### Mode: local (no commits, no push)
 1. Add the ai-rules subtree (creates a local commit):
-   `git subtree add --prefix <AI_RULES_PATH> https://github.com/fabian-barney/ai-rules.git <REF> --squash`
+   `git subtree add --prefix "<AI_RULES_PATH>" https://github.com/fabian-barney/ai-rules.git <REF> --squash`
    - Resolve `REF` using the deterministic rules above.
    - If Git requires an author identity, set it locally:
      git config --local user.name "Your Name"
@@ -122,7 +122,7 @@ Local-only update note:
 
 ### Mode: git (tracked in repo)
 1. Add the ai-rules subtree:
-   `git subtree add --prefix <AI_RULES_PATH> https://github.com/fabian-barney/ai-rules.git <REF> --squash`
+   `git subtree add --prefix "<AI_RULES_PATH>" https://github.com/fabian-barney/ai-rules.git <REF> --squash`
    - Resolve `REF` using the deterministic rules above.
    - If Git requires an author identity, set it locally:
      git config --local user.name "Your Name"
@@ -165,7 +165,7 @@ Local-only update note:
 8. Commit and push the changes.
 
 Git update note:
-- Use `git subtree pull --prefix <AI_RULES_PATH> https://github.com/fabian-barney/ai-rules.git <REF> --squash`
+- Use `git subtree pull --prefix "<AI_RULES_PATH>" https://github.com/fabian-barney/ai-rules.git <REF> --squash`
   and commit the update.
 
 ## Entry Point Templates

--- a/AI-RULES/LESSONS_LEARNED/2026-02-01-release-version-examples.md
+++ b/AI-RULES/LESSONS_LEARNED/2026-02-01-release-version-examples.md
@@ -10,18 +10,20 @@ were not updated before creating the release commit and tag. This resulted in
 the release tag containing outdated version references, requiring a follow-up
 commit after the release.
 
-The release instructions in RELEASE.md step 4 clearly stated to update versioned
-examples, but the step was skipped.
+The release instructions in [RELEASE.md](../RELEASE.md) (step 4) clearly stated
+to update versioned examples, but the step was skipped.
 
 ## Prevention
 Before creating the release commit:
-1. Search for the previous version string (e.g., `v2.1.0`) across all files.
-2. Update every occurrence in example prompts to the new version.
+1. Search for the last released version tag string (for example grep `v2.1.0`
+   when releasing `v2.1.1`) across all files.
+2. Update every versioned reference found (README example prompts and any other
+   documentation) to the new version.
 3. Verify the changes are staged before committing.
 
 Checklist for AI agents:
-- [ ] Run `git grep "vX.Y.Z"` (previous version) to find all references.
-- [ ] Update README.md example prompts.
-- [ ] Check for version references in any other documentation.
+- [ ] Run `git grep "vX.Y.Z"` (using the last released version tag) to find all
+      references.
+- [ ] Update README.md example prompts and any other versioned documentation.
 - [ ] Stage all version updates with the changelog in the same commit.
 - [ ] Only then create the annotated tag.

--- a/AI-RULES/LESSONS_LEARNED/2026-02-01-release-version-examples.md
+++ b/AI-RULES/LESSONS_LEARNED/2026-02-01-release-version-examples.md
@@ -15,8 +15,8 @@ to update versioned examples, but the step was skipped.
 
 ## Prevention
 Before creating the release commit:
-1. Search for the last released version tag string (for example grep `v2.1.0`
-   when releasing `v2.1.1`) across all files.
+1. Search for the last released version tag string (for example, run
+   `git grep "v2.1.0"` when releasing `v2.1.1`) across all files.
 2. Update every versioned reference found (README example prompts and any other
    documentation) to the new version.
 3. Verify the changes are staged before committing.


### PR DESCRIPTION
Closes #396

## Implementation Summary
- Scope: close the historical unresolved review backlog and fix the findings that were still valid on current `main`.
- Key changes:
  - link the release lesson learned directly to `RELEASE.md` and clarify the release-version checklist wording
  - quote `<AI_RULES_PATH>` in subtree commands in `AGENTS_TEMPLATE.md`
- Non-goals: no broader rewrite of setup/update guidance beyond the findings that were still valid on current `main`.

## Review Focus
- Generated/copied files and standard imports that can be skimmed: N/A
- Non-obvious code paths and rationale: all historical unresolved review threads were re-evaluated against current `main`; only five findings remained valid and required code changes.

## Validation
- Tests executed: `npx --yes markdownlint-cli2 --config .markdownlint.json AGENTS_TEMPLATE.md AI-RULES/LESSONS_LEARNED/2026-02-01-release-version-examples.md`
- Manual checks: verified the new relative `RELEASE.md` link target and resolved every historical review thread with a judgment comment.
- Residual risks: no local full-repo linkcheck run because `lychee` is not installed in this environment.