### PR TITLE
Update documentation workflow actions

### DIFF
--- a/.github/workflows/docs-check.yml
+++ b/.github/workflows/docs-check.yml
@@ -12,8 +12,8 @@ jobs:
   markdownlint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
-      - uses: DavidAnson/markdownlint-cli2-action@b4c9feab76d8025d1e83c653fa3990936df0e6c8
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - uses: DavidAnson/markdownlint-cli2-action@ded1f9488f68a970bc66ea5619e13e9b52e601cd
         with:
           globs: |
             **/*.md
@@ -23,7 +23,7 @@ jobs:
   linkcheck:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
-      - uses: lycheeverse/lychee-action@7cd0af4c74a61395d455af97419279d86aafaede
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - uses: lycheeverse/lychee-action@8646ba30535128ac92d33dfc9133794bfdd9b411
         with:
           args: --no-progress --verbose --exclude-mail "**/*.md"

--- a/.github/workflows/docs-check.yml
+++ b/.github/workflows/docs-check.yml
@@ -26,4 +26,4 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
       - uses: lycheeverse/lychee-action@8646ba30535128ac92d33dfc9133794bfdd9b411
         with:
-          args: --no-progress --verbose --exclude-mail "**/*.md"
+          args: --no-progress --verbose "**/*.md"


### PR DESCRIPTION
## Summary
- update pinned docs-check workflow actions for checkout, markdownlint-cli2-action, and lychee-action
- keep repository contents unchanged; this PR only updates dependency surfaces in GitHub Actions
- remove lychee's obsolete `--exclude-mail` argument; current lychee keeps email checks opt-in via `--include-mail`, and CI linkcheck passes without checking placeholder email addresses

## Validation
- `npx -y prettier@3.8.3 --parser yaml .github/workflows/docs-check.yml`
- docs workflow YAML parse via Python `yaml.safe_load`

Closes #398