### PR TITLE
Update dependency workflow pins

### DIFF
--- a/.github/workflows/docs-check.yml
+++ b/.github/workflows/docs-check.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
-      - uses: DavidAnson/markdownlint-cli2-action@ded1f9488f68a970bc66ea5619e13e9b52e601cd
+      - uses: DavidAnson/markdownlint-cli2-action@fa0cd0f1a052f54da593c83860f2292982f5d142
         with:
           globs: |
             **/*.md


### PR DESCRIPTION
## Summary
- Refreshes the markdownlint workflow action pin.

## Version decisions
- Workflow-only update; no runtime or package-manager floor changes.

## Validation
- `git diff --check`
- Local actionlint was unavailable; remote GitHub Actions is the final workflow syntax gate.

Closes #400